### PR TITLE
Reparación directorio_sentencias.

### DIFF
--- a/cli/commands/cmd_abogados.py
+++ b/cli/commands/cmd_abogados.py
@@ -45,7 +45,7 @@ def alimentar(entrada_csv):
                 ano = int(row["año"])
                 mes = int(row["mes"])
                 dia = int(row["dia"])
-                numero = row["número"]
+                numero = row["numero"]
                 nombre = row["nombre"]
                 libro = row["libro"]
             except (IndexError, ValueError):

--- a/cli/commands/cmd_sentencias.py
+++ b/cli/commands/cmd_sentencias.py
@@ -39,7 +39,7 @@ def refrescar(autoridad_clave):
     if autoridad.es_notaria:
         click.echo(f"La autoridad {autoridad_clave} es una notaría")
         return
-    if autoridad.directorio_listas_de_acuerdos is None or autoridad.directorio_listas_de_acuerdos == "":
+    if autoridad.directorio_sentencias is None or autoridad.directorio_sentencias == "":
         click.echo(f"La autoridad {autoridad_clave} no tiene directorio para listas de acuerdos")
         return
     app.task_queue.enqueue(
@@ -60,7 +60,7 @@ def refrescar_todos():
             continue
         if not autoridad.es_jurisdiccional:
             continue
-        if autoridad.directorio_listas_de_acuerdos is None or autoridad.directorio_listas_de_acuerdos == "":
+        if autoridad.directorio_sentencias is None or autoridad.directorio_sentencias == "":
             continue
         app.task_queue.enqueue(
             "plataforma_web.blueprints.sentencias.tasks.refrescar",

--- a/plataforma_web/blueprints/sentencias/views.py
+++ b/plataforma_web/blueprints/sentencias/views.py
@@ -246,7 +246,7 @@ def new():
             archivo_str = f"{fecha_str}-{sentencia_str}-{expediente_str}-G-{sentencia.encode_id()}.pdf"
         else:
             archivo_str = f"{fecha_str}-{sentencia_str}-{expediente_str}-{sentencia.encode_id()}.pdf"
-        ruta_str = str(Path(SUBDIRECTORIO, autoridad.directorio_glosas, ano_str, mes_str, archivo_str))
+        ruta_str = str(Path(SUBDIRECTORIO, autoridad.directorio_sentencias, ano_str, mes_str, archivo_str))
 
         # Subir el archivo
         deposito = current_app.config["CLOUD_STORAGE_DEPOSITO"]
@@ -356,7 +356,7 @@ def new_for_autoridad(autoridad_id):
             archivo_str = f"{fecha_str}-{sentencia_str}-{expediente_str}-{sentencia.encode_id()}.pdf"
         else:
             archivo_str = f"{fecha_str}-{sentencia_str}-{expediente_str}-G-{sentencia.encode_id()}.pdf"
-        ruta_str = str(Path(SUBDIRECTORIO, autoridad.directorio_glosas, ano_str, mes_str, archivo_str))
+        ruta_str = str(Path(SUBDIRECTORIO, autoridad.directorio_sentencias, ano_str, mes_str, archivo_str))
 
         # Subir el archivo
         deposito = current_app.config["CLOUD_STORAGE_DEPOSITO"]


### PR DESCRIPTION
Este error causaba que al subir sentencias (donde el directorio de glosas es vacío) se colocaban en una ruta mala.