### PR TITLE
Columnas archivo y url no son NULL.

### DIFF
--- a/plataforma_web/blueprints/edictos/models.py
+++ b/plataforma_web/blueprints/edictos/models.py
@@ -23,10 +23,10 @@ class Edicto(db.Model, UniversalMixin):
     # Columnas
     fecha = db.Column(db.Date, index=True, nullable=False)
     descripcion = db.Column(db.String(256), nullable=False)
-    expediente = db.Column(db.String(16), nullable=False, default="", server_default="")  # No debe ser nulo, puede ser texto vacío por defecto ""
-    numero_publicacion = db.Column(db.String(16), nullable=False, default="", server_default="")  # No debe ser nulo, puede ser texto vacío por defecto ""
-    archivo = db.Column(db.String(256))
-    url = db.Column(db.String(512))
+    expediente = db.Column(db.String(16), nullable=False, default="", server_default="")
+    numero_publicacion = db.Column(db.String(16), nullable=False, default="", server_default="")
+    archivo = db.Column(db.String(256), nullable=False, default="", server_default="")
+    url = db.Column(db.String(512), nullable=False, default="", server_default="")
 
     def __repr__(self):
         """Representación"""

--- a/plataforma_web/blueprints/glosas/models.py
+++ b/plataforma_web/blueprints/glosas/models.py
@@ -40,8 +40,8 @@ class Glosa(db.Model, UniversalMixin):
     tipo_juicio = db.Column(db.Enum(*TIPOS_JUICIOS, name="tipos_juicios", native_enum=False), index=True, nullable=False)
     descripcion = db.Column(db.String(256), nullable=False)
     expediente = db.Column(db.String(16), nullable=False)
-    archivo = db.Column(db.String(256))
-    url = db.Column(db.String(512))
+    archivo = db.Column(db.String(256), nullable=False, default="", server_default="")
+    url = db.Column(db.String(512), nullable=False, default="", server_default="")
 
     def __repr__(self):
         """Representación"""

--- a/plataforma_web/blueprints/listas_de_acuerdos/models.py
+++ b/plataforma_web/blueprints/listas_de_acuerdos/models.py
@@ -21,8 +21,8 @@ class ListaDeAcuerdo(db.Model, UniversalMixin):
     # Columnas
     fecha = db.Column(db.Date, index=True, nullable=False)
     descripcion = db.Column(db.String(256), nullable=False)
-    archivo = db.Column(db.String(256))
-    url = db.Column(db.String(512))
+    archivo = db.Column(db.String(256), nullable=False, default="", server_default="")
+    url = db.Column(db.String(512), nullable=False, default="", server_default="")
 
     # Hijos
     listas_de_acuerdos_acuerdos = db.relationship('ListaDeAcuerdoAcuerdo', back_populates='lista_de_acuerdo')

--- a/plataforma_web/blueprints/sentencias/models.py
+++ b/plataforma_web/blueprints/sentencias/models.py
@@ -27,8 +27,8 @@ class Sentencia(db.Model, UniversalMixin):
     fecha = db.Column(db.Date, index=True, nullable=False)
     descripcion = db.Column(db.String(1024), nullable=False, default="", server_default="")
     es_perspectiva_genero = db.Column(db.Boolean, nullable=False, default=False)
-    archivo = db.Column(db.String(256))
-    url = db.Column(db.String(512))
+    archivo = db.Column(db.String(256), nullable=False, default="", server_default="")
+    url = db.Column(db.String(512), nullable=False, default="", server_default="")
 
     def __repr__(self):
         """Representación"""

--- a/plataforma_web/blueprints/transcripciones/models.py
+++ b/plataforma_web/blueprints/transcripciones/models.py
@@ -21,7 +21,7 @@ class Transcripcion(db.Model, UniversalMixin):
     # Columnas
     descripcion = db.Column(db.String(256), nullable=False)
     expediente = db.Column(db.String(24))
-    audio_url = db.Column(db.String(256))
+    audio_url = db.Column(db.String(256), nullable=False, default="", server_default="")
     transcripcion = db.Column(db.Text())
 
     def __repr__(self):

--- a/sql/redefinir_archivo_url.session.sql
+++ b/sql/redefinir_archivo_url.session.sql
@@ -1,0 +1,35 @@
+-- @block edictos
+SELECT COUNT(*) FROM `edictos` WHERE `url` IS NULL;
+
+-- @block edictos update alter
+UPDATE `edictos` SET `archivo` = '' WHERE `archivo` is NULL;
+UPDATE `edictos` SET `url` = '' WHERE `url` is NULL;
+ALTER TABLE `edictos` MODIFY `archivo` varchar(256) NOT NULL DEFAULT '';
+ALTER TABLE `edictos` MODIFY `url` varchar(512) NOT NULL DEFAULT '';
+
+-- @block glosas
+SELECT COUNT(*) FROM `glosas` WHERE `url` IS NULL;
+
+-- @block glosas update alter
+UPDATE `glosas` SET `archivo` = '' WHERE `archivo` is NULL;
+UPDATE `glosas` SET `url` = '' WHERE `url` is NULL;
+ALTER TABLE `glosas` MODIFY `archivo` varchar(256) NOT NULL DEFAULT '';
+ALTER TABLE `glosas` MODIFY `url` varchar(512) NOT NULL DEFAULT '';
+
+-- @block listas_de_acuerdos
+SELECT COUNT(*) FROM `listas_de_acuerdos` WHERE `url` IS NULL;
+
+-- @block listas_de_acuerdos update alter
+UPDATE `listas_de_acuerdos` SET `archivo` = '' WHERE `archivo` is NULL;
+UPDATE `listas_de_acuerdos` SET `url` = '' WHERE `url` is NULL;
+ALTER TABLE `listas_de_acuerdos` MODIFY `archivo` varchar(256) NOT NULL DEFAULT '';
+ALTER TABLE `listas_de_acuerdos` MODIFY `url` varchar(512) NOT NULL DEFAULT '';
+
+-- @block sentencias
+SELECT COUNT(*) FROM `sentencias` WHERE `url` IS NULL;
+
+-- @block sentencias nulos a texto vacio
+UPDATE `sentencias` SET `archivo` = '' WHERE `archivo` is NULL;
+UPDATE `sentencias` SET `url` = '' WHERE `url` is NULL;
+ALTER TABLE `sentencias` MODIFY `archivo` varchar(256) NOT NULL DEFAULT '';
+ALTER TABLE `sentencias` MODIFY `url` varchar(512) NOT NULL DEFAULT '';


### PR DESCRIPTION
Cuando se da de alta un edicto, glosa, lista de acuerdo o sentencia, primero se inserta el registro sin archivo y url; luego se obtiene el id; después se actualiza con el archivo y el url. No deben de quedar registros con archivo y url como NULL; porque la API con Pydantic causa error.