### PR TITLE
A prueba el envío de reportes diarios de Listas de Acuerdos

### DIFF
--- a/cli/commands/cmd_listas_de_acuerdos.py
+++ b/cli/commands/cmd_listas_de_acuerdos.py
@@ -1,9 +1,11 @@
 """
 Listas de Acuerdos
 
+- enviar_reporte: Enviar via correo electronico el reporte de listas de acuerdos
 - refrescar: Rastrear el depósito para agregar o dar de baja
 - refrescar_todos: Rastrear el depósito para agregar o dar de baja
 """
+from datetime import datetime
 import click
 
 from plataforma_web.app import create_app
@@ -18,6 +20,25 @@ db.app = app
 @click.group()
 def cli():
     """Listas de Acuerdos"""
+
+
+@click.command()
+@click.option("--fecha", default="", type=str, help="Fecha a consultar")
+def enviar_reporte(fecha):
+    """Enviar via correo electronico el reporte de listas de acuerdos"""
+    if fecha != "":
+        try:
+            fecha_date = datetime.strptime(fecha, "%Y-%m-%d")
+        except ValueError as mensaje:
+            click.echo(f"AVISO: Fecha incorrecta {mensaje}")
+            return
+    else:
+        fecha_date = None
+    app.task_queue.enqueue(
+        "plataforma_web.blueprints.listas_de_acuerdos.tasks.enviar_reporte",
+        fecha=fecha_date,
+    )
+    click.echo("Enviar reporte de listas de acuerdo se está ejecutando en el fondo.")
 
 
 @click.command()
@@ -70,5 +91,6 @@ def refrescar_todos():
     click.echo(f"Se lanzaron {contador} tareas para ejecutar en el fondo.")
 
 
+cli.add_command(enviar_reporte)
 cli.add_command(refrescar)
 cli.add_command(refrescar_todos)

--- a/notebooks/listas_de_acuerdos-diario.ipynb
+++ b/notebooks/listas_de_acuerdos-diario.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "source": [
     "from datetime import date\n",
     "\n",
@@ -34,16 +34,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "source": [
     "# Distritos\n",
     "distritos_select = db.session.query(Distrito.id, Distrito.nombre).\\\n",
     "    filter(Distrito.es_distrito_judicial == True).\\\n",
     "    filter(Distrito.estatus == \"A\").statement\n",
     "distritos = pd.read_sql_query(sql=distritos_select, con=db.engine)\n",
-    "distritos"
+    "for index, row in distritos.iterrows():\n",
+    "    print(row['id'], row['nombre'])\n"
    ],
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "1 Distrito Judicial de Acuña\n",
+      "2 Distrito Judicial de Monclova\n",
+      "3 Distrito Judicial de Parras de la Fuente\n",
+      "4 Distrito Judicial de Río Grande (Piedras Negras)\n",
+      "5 Distrito Judicial de Sabinas\n",
+      "6 Distrito Judicial de Saltillo\n",
+      "7 Distrito Judicial de San Pedro de las Colonias\n",
+      "8 Distrito Judicial de Torreón\n",
+      "14 Salas\n",
+      "15 Pleno del Tribunal Constitucional\n",
+      "16 Pleno del Tribunal Superior de Justicia\n",
+      "17 Tribunales Distritales\n",
+      "18 Órganos Especializados\n"
+     ]
+    }
+   ],
    "metadata": {}
   },
   {
@@ -51,7 +72,7 @@
    "execution_count": null,
    "source": [
     "# Distrito Judicial\n",
-    "distrito = Distrito.query.get(14)  # 6: Saltillo, 8: Torreon, 14: Salas\n",
+    "distrito = Distrito.query.get(6)  # 6: Saltillo, 8: Torreon, 14: Salas\n",
     "\n",
     "# Juzgados\n",
     "autoridades_select = db.session.query(Autoridad.id, Autoridad.clave, Autoridad.descripcion_corta).\\\n",
@@ -71,7 +92,7 @@
    "execution_count": null,
    "source": [
     "# Fecha\n",
-    "fecha = date(year=2021, month=9, day=1)\n",
+    "fecha = date(year=2021, month=9, day=2)\n",
     "\n",
     "# Listas de acuerdos de esa fecha\n",
     "listas_de_acuerdos_select = db.session.query(Autoridad.clave, ListaDeAcuerdo.archivo, ListaDeAcuerdo.creado).\\\n",

--- a/plataforma_web/blueprints/cid_procedimientos/forms.py
+++ b/plataforma_web/blueprints/cid_procedimientos/forms.py
@@ -3,10 +3,11 @@ CID Procedimientos, formularios
 """
 from flask_wtf import FlaskForm
 from wtforms import DateField, IntegerField, StringField, SubmitField
+from wtforms.ext.sqlalchemy.fields import QuerySelectField
 from wtforms.validators import DataRequired, Length, Optional
+
 from lib.wtforms import JSONField
 from plataforma_web.blueprints.usuarios.models import Usuario
-from wtforms.ext.sqlalchemy.fields import QuerySelectField
 
 
 def usuarios_email_opciones():

--- a/plataforma_web/blueprints/listas_de_acuerdos/tasks.py
+++ b/plataforma_web/blueprints/listas_de_acuerdos/tasks.py
@@ -231,32 +231,32 @@ def refrescar(autoridad_id: int, usuario_id: int = None):
     return mensaje_final
 
 
-def enviar_reporte():
+def enviar_reporte(fecha: date = None):
     """Enviar via correo electronico el reporte de listas de acuerdos"""
 
-    # Tiempos
+    # Fecha a consultar
+    if fecha is None:
+        fecha = date.today()
+
+    # Momento en que se elabora este reporte
     momento = datetime.now()
     momento_str = momento.strftime("%d/%B/%Y %I:%M%p")
-    hoy = date.today()
+    subject = f"Listas de Acuerdos del {fecha.strftime('%d/%B/%Y')}"
 
     # Cabecera
-    bitacora.info("Reporte diario del %s", momento_str)
-    contenidos = [
-        "<h1>PJECZ Plataforma Web</h1>",
-        f"<p>Reporte diario de <strong>Listas de Acuerdos</strong> del {momento_str}</p>",
-    ]
+    bitacora.info("Inicia enviar reporte de %s", momento_str)
+    contenidos = [f"<h1>PJECZ Plataforma Web</h1><h2>{subject}</h2><p>Fecha de elaboración: {momento_str}.<br>ESTE MENSAJE ES ELABORADO POR UN PROGRAMA. FAVOR DE NO RESPONDER.</p>"]
 
     # Distritos
     distritos_select = db.session.query(Distrito.id, Distrito.nombre).filter(Distrito.es_distrito_judicial == True).filter(Distrito.estatus == "A").statement
     distritos = pd.read_sql_query(sql=distritos_select, con=db.engine)
     total = 0
-    for distrito in distritos:
-        contenidos.append(f"<h3>{distrito.nombre}</h3>")
+    for distrito_index, distrito_row in distritos.iterrows():
 
         # Juzgados
         autoridades_select = (
             db.session.query(Autoridad.id, Autoridad.clave, Autoridad.descripcion_corta)
-            .filter(Autoridad.distrito_id == distrito.id)
+            .filter(Autoridad.distrito_id == distrito_row["id"])
             .filter(Autoridad.es_jurisdiccional == True)
             .filter(Autoridad.es_notaria == False)
             .filter(Autoridad.estatus == "A")
@@ -267,36 +267,36 @@ def enviar_reporte():
 
         # Listas de acuerdos
         listas_de_acuerdos_select = (
-            db.session.query(Autoridad.clave, ListaDeAcuerdo.archivo, ListaDeAcuerdo.creado)
+            db.session.query(Autoridad.clave, ListaDeAcuerdo.fecha, ListaDeAcuerdo.url)
             .join(Autoridad)
             .filter(ListaDeAcuerdo.autoridad_id.in_(autoridades.id))
-            .filter(ListaDeAcuerdo.fecha == hoy)
+            .filter(ListaDeAcuerdo.fecha == fecha)
             .filter(ListaDeAcuerdo.estatus == "A")
-            .order_by(ListaDeAcuerdo.creado)
+            .order_by(Autoridad.clave, ListaDeAcuerdo.creado)
             .statement
         )
         listas_de_acuerdos = pd.read_sql_query(sql=listas_de_acuerdos_select, con=db.engine)
-        listas_de_acuerdos.columns = ["clave2", "archivo", "creado"]
+        listas_de_acuerdos.columns = ["clave2", "fecha", "url"]
 
         # Reporte
-        diario = pd.merge(autoridades, listas_de_acuerdos, left_on="clave", right_on="clave2", how="left").drop("clave2", axis=1)
-        contenidos.append(diario.to_html())
+        diario = pd.merge(autoridades, listas_de_acuerdos, left_on="clave", right_on="clave2", how="left").drop("clave", axis=1).drop("clave2", axis=1).drop("id", axis=1)
+        contenidos.append("<h3>" + distrito_row["nombre"] + "</h3>" + diario.to_html())
 
         # A bitacora
         cantidad = len(listas_de_acuerdos)
-        bitacora.info("- En %s hay %s", distrito.nombre_corto, cantidad)
+        bitacora.info("- En %s hay %s", distrito_row["nombre"], cantidad)
         total += cantidad
 
     # Pie del mensaje
-    contenidos.append("Este mensaje de crea de forma automatica. Favor de no responder.")
+    contenidos.append("<p>ESTE MENSAJE ES ELABORADO POR UN PROGRAMA. FAVOR DE NO RESPONDER.</p>")
 
     # Mensaje via correo electronico
     api_key = os.environ.get("SENDGRID_API_KEY", "Debe estar definida como variable de entorno")
     sg = sendgrid.SendGridAPIClient(api_key=api_key)
-    from_email = Email("informatica@pjecz.gob.mx")
-    to_email = To("guillermo.valdes@pjecz.gob.mx")
-    subject = "Plataforma Web - Listas de Acuerdos"
-    content = Content("text/html", "/n".join(contenidos))
+    from_email = Email("plataforma.web@pjecz.gob.mx")
+    to_email = To("plataforma.web.reportes@pjecz.gob.mx")
+    # subject = "Plataforma Web - Listas de Acuerdos"
+    content = Content("text/html", "<br>".join(contenidos))
     mail = Mail(from_email, to_email, subject, content)
     response = sg.client.mail.send.post(request_body=mail.get())
     bitacora.info(response.status_code)

--- a/plataforma_web/blueprints/listas_de_acuerdos/views.py
+++ b/plataforma_web/blueprints/listas_de_acuerdos/views.py
@@ -28,7 +28,7 @@ listas_de_acuerdos = Blueprint("listas_de_acuerdos", __name__, template_folder="
 
 MODULO = "LISTAS DE ACUERDOS"
 SUBDIRECTORIO = "Listas de Acuerdos"
-LIMITE_DIAS = 3  # Es el maximo, aunque autoridad.limite_dias_listas_de_acuerdos sea mayor
+LIMITE_DIAS = 7  # Es el máximo, aunque autoridad.limite_dias_listas_de_acuerdos sea mayor, gana el menor
 LIMITE_ADMINISTRADORES_DIAS = 90
 
 


### PR DESCRIPTION
Novedades:

- Integración de Sendgrid para enviar mensaje por correo electrónico.
- Usa Pandas para elaborar el reporte diario de listas de acuerdos.
- Envia el mensaje al grupo de distribucion plataforma.web.reportes@
- La VM Tierra tiene en su cron hacer esta tarea de lunes a viernes a las 5:30 PM