### PR TITLE
Reparacion error al comparar tiempos. Closes #224

### DIFF
--- a/plataforma_web/blueprints/edictos/views.py
+++ b/plataforma_web/blueprints/edictos/views.py
@@ -708,14 +708,16 @@ def delete(edicto_id):
         hoy = datetime.date.today()
         hoy_dt = datetime.datetime(year=hoy.year, month=hoy.month, day=hoy.day)
         if current_user.can_admin("EDICTOS"):
-            if hoy_dt + datetime.timedelta(days=-LIMITE_ADMINISTRADORES_DIAS) <= edicto.creado:
+            limite_dt = hoy_dt + datetime.timedelta(days=-LIMITE_ADMINISTRADORES_DIAS)
+            if limite_dt.timestamp() <= edicto.creado.timestamp():
                 edicto.delete()
                 bitacora = delete_success(edicto)
                 flash(bitacora.descripcion, "success")
             else:
                 flash(f"No tiene permiso para eliminar si fue creado hace {LIMITE_ADMINISTRADORES_DIAS} días o más.", "warning")
         elif current_user.autoridad_id == edicto.autoridad_id:
-            if hoy_dt + datetime.timedelta(days=-LIMITE_DIAS) <= edicto.creado:
+            limite_dt = hoy_dt + datetime.timedelta(days=-LIMITE_DIAS)
+            if limite_dt.timestamp() <= edicto.creado.timestamp():
                 edicto.delete()
                 bitacora = delete_success(edicto)
                 flash(bitacora.descripcion, "success")
@@ -747,14 +749,16 @@ def recover(edicto_id):
         hoy = datetime.date.today()
         hoy_dt = datetime.datetime(year=hoy.year, month=hoy.month, day=hoy.day)
         if current_user.can_admin("EDICTOS"):
-            if hoy_dt + datetime.timedelta(days=-LIMITE_ADMINISTRADORES_DIAS) <= edicto.creado:
+            limite_dt = hoy_dt + datetime.timedelta(days=-LIMITE_ADMINISTRADORES_DIAS)
+            if limite_dt.timestamp() <= edicto.creado.timestamp():
                 edicto.recover()
                 bitacora = recover_success(edicto)
                 flash(bitacora.descripcion, "success")
             else:
                 flash(f"No tiene permiso para recuperar si fue creado hace {LIMITE_ADMINISTRADORES_DIAS} días o más.", "warning")
         elif current_user.autoridad_id == edicto.autoridad_id:
-            if hoy_dt + datetime.timedelta(days=-LIMITE_DIAS) <= edicto.creado:
+            limite_dt = hoy_dt + datetime.timedelta(days=-LIMITE_DIAS)
+            if limite_dt.timestamp() <= edicto.creado.timestamp():
                 edicto.recover()
                 bitacora = recover_success(edicto)
                 flash(bitacora.descripcion, "success")

--- a/plataforma_web/blueprints/glosas/views.py
+++ b/plataforma_web/blueprints/glosas/views.py
@@ -643,14 +643,16 @@ def delete(glosa_id):
         hoy = datetime.date.today()
         hoy_dt = datetime.datetime(year=hoy.year, month=hoy.month, day=hoy.day)
         if current_user.can_admin("GLOSAS"):
-            if hoy_dt + datetime.timedelta(days=-LIMITE_ADMINISTRADORES_DIAS) <= glosa.creado:
+            limite_dt = hoy_dt + datetime.timedelta(days=-LIMITE_ADMINISTRADORES_DIAS)
+            if limite_dt.timestamp() <= glosa.creado.timestamp():
                 glosa.delete()
                 bitacora = delete_success(glosa)
                 flash(bitacora.descripcion, "success")
             else:
                 flash(f"No tiene permiso para eliminar si fue creado hace {LIMITE_ADMINISTRADORES_DIAS} días o más.", "warning")
         elif current_user.autoridad_id == glosa.autoridad_id:
-            if hoy_dt + datetime.timedelta(days=-LIMITE_DIAS) <= glosa.creado:
+            limite_dt = hoy_dt + datetime.timedelta(days=-LIMITE_DIAS)
+            if limite_dt.timestamp() <= glosa.creado.timestamp():
                 glosa.delete()
                 bitacora = delete_success(glosa)
                 flash(bitacora.descripcion, "success")
@@ -682,14 +684,16 @@ def recover(glosa_id):
         hoy = datetime.date.today()
         hoy_dt = datetime.datetime(year=hoy.year, month=hoy.month, day=hoy.day)
         if current_user.can_admin("GLOSAS"):
-            if hoy_dt + datetime.timedelta(days=-LIMITE_ADMINISTRADORES_DIAS) <= glosa.creado:
+            limite_dt = hoy_dt + datetime.timedelta(days=-LIMITE_ADMINISTRADORES_DIAS)
+            if limite_dt.timestamp() <= glosa.creado.timestamp():
                 glosa.recover()
                 bitacora = recover_success(glosa)
                 flash(bitacora.descripcion, "success")
             else:
                 flash(f"No tiene permiso para recuperar si fue creado hace {LIMITE_ADMINISTRADORES_DIAS} días o más.", "warning")
         elif current_user.autoridad_id == glosa.autoridad_id:
-            if hoy_dt + datetime.timedelta(days=-LIMITE_DIAS) <= glosa.creado:
+            limite_dt = hoy_dt + datetime.timedelta(days=-LIMITE_DIAS)
+            if limite_dt.timestamp() <= glosa.creado.timestamp():
                 glosa.recover()
                 bitacora = recover_success(glosa)
                 flash(bitacora.descripcion, "success")

--- a/plataforma_web/blueprints/listas_de_acuerdos/views.py
+++ b/plataforma_web/blueprints/listas_de_acuerdos/views.py
@@ -29,7 +29,7 @@ listas_de_acuerdos = Blueprint("listas_de_acuerdos", __name__, template_folder="
 
 MODULO = "LISTAS DE ACUERDOS"
 SUBDIRECTORIO = "Listas de Acuerdos"
-LIMITE_DIAS = 7  # Es el máximo, aunque autoridad.limite_dias_listas_de_acuerdos sea mayor, gana el menor
+LIMITE_DIAS = 30  # Es el máximo, aunque autoridad.limite_dias_listas_de_acuerdos sea mayor, gana el menor
 LIMITE_ADMINISTRADORES_DIAS = 90
 
 
@@ -592,7 +592,8 @@ def delete(lista_de_acuerdo_id):
         if current_user.can_admin("LISTAS DE ACUERDOS"):
             hoy = datetime.date.today()
             hoy_dt = datetime.datetime(year=hoy.year, month=hoy.month, day=hoy.day)
-            if hoy_dt + datetime.timedelta(days=-LIMITE_ADMINISTRADORES_DIAS) <= lista_de_acuerdo.creado:
+            limite_dt = hoy_dt + datetime.timedelta(days=-LIMITE_ADMINISTRADORES_DIAS)
+            if limite_dt.timestamp() <= lista_de_acuerdo.creado.timestamp():
                 lista_de_acuerdo.delete()
                 bitacora = delete_success(lista_de_acuerdo)
                 flash(bitacora.descripcion, "success")
@@ -631,7 +632,8 @@ def recover(lista_de_acuerdo_id):
             if current_user.can_admin("LISTAS DE ACUERDOS"):
                 hoy = datetime.date.today()
                 hoy_dt = datetime.datetime(year=hoy.year, month=hoy.month, day=hoy.day)
-                if hoy_dt + datetime.timedelta(days=-LIMITE_ADMINISTRADORES_DIAS) <= lista_de_acuerdo.creado:
+                limite_dt = hoy_dt + datetime.timedelta(days=-LIMITE_ADMINISTRADORES_DIAS)
+                if limite_dt.timestamp() <= lista_de_acuerdo.creado.timestamp():
                     lista_de_acuerdo.recover()
                     bitacora = recover_success(lista_de_acuerdo)
                     flash(bitacora.descripcion, "success")

--- a/plataforma_web/blueprints/sentencias/views.py
+++ b/plataforma_web/blueprints/sentencias/views.py
@@ -746,14 +746,16 @@ def delete(sentencia_id):
         hoy = datetime.date.today()
         hoy_dt = datetime.datetime(year=hoy.year, month=hoy.month, day=hoy.day)
         if current_user.can_admin("SENTENCIAS"):
-            if hoy_dt + datetime.timedelta(days=-LIMITE_ADMINISTRADORES_DIAS) <= sentencia.creado:
+            limite_dt = hoy_dt + datetime.timedelta(days=-LIMITE_ADMINISTRADORES_DIAS)
+            if limite_dt.timestamp() <= sentencia.creado.timestamp():
                 sentencia.delete()
                 bitacora = delete_success(sentencia)
                 flash(bitacora.descripcion, "success")
             else:
                 flash(f"No tiene permiso para eliminar si fue creado hace {LIMITE_ADMINISTRADORES_DIAS} días o más.", "warning")
         elif current_user.autoridad_id == sentencia.autoridad_id:
-            if hoy_dt + datetime.timedelta(days=-LIMITE_DIAS) <= sentencia.creado:
+            limite_dt = hoy_dt + datetime.timedelta(days=-LIMITE_DIAS)
+            if limite_dt.timestamp() <= sentencia.creado.timestamp():
                 sentencia.delete()
                 bitacora = delete_success(sentencia)
                 flash(bitacora.descripcion, "success")
@@ -785,14 +787,16 @@ def recover(sentencia_id):
         hoy = datetime.date.today()
         hoy_dt = datetime.datetime(year=hoy.year, month=hoy.month, day=hoy.day)
         if current_user.can_admin("SENTENCIAS"):
-            if hoy_dt + datetime.timedelta(days=-LIMITE_ADMINISTRADORES_DIAS) <= sentencia.creado:
+            limite_dt = hoy_dt + datetime.timedelta(days=-LIMITE_ADMINISTRADORES_DIAS)
+            if limite_dt.timestamp() <= sentencia.creado.timestamp():
                 sentencia.recover()
                 bitacora = recover_success(sentencia)
                 flash(bitacora.descripcion, "success")
             else:
                 flash(f"No tiene permiso para eliminar si fue creado hace {LIMITE_ADMINISTRADORES_DIAS} días o más.", "warning")
         elif current_user.autoridad_id == sentencia.autoridad_id:
-            if hoy_dt + datetime.timedelta(days=-LIMITE_DIAS) <= sentencia.creado:
+            limite_dt = hoy_dt + datetime.timedelta(days=-LIMITE_DIAS)
+            if limite_dt.timestamp() <= sentencia.creado.timestamp():
                 sentencia.recover()
                 bitacora = recover_success(sentencia)
                 flash(bitacora.descripcion, "success")


### PR DESCRIPTION
Al eliminar y recuperar se revisan los tiempos en base a los limites de dias. Ahora se comparan con timestamp para evitar el problema de con y sin zona horaria.