### PR TITLE
Expulsión de usuarios en tickets que no le corresponden

### DIFF
--- a/plataforma_web/blueprints/soportes_tickets/templates/soportes_tickets/detail.jinja2
+++ b/plataforma_web/blueprints/soportes_tickets/templates/soportes_tickets/detail.jinja2
@@ -8,7 +8,7 @@
 
 {% block topbar_actions %}
     {% call topbar.page_buttons('Ticket ' + soporte_ticket.id | string) %}
-        {% if soporte_ticket.estado == 'CANCELADO' %}
+        {% if soporte_ticket.estado == 'CANCELADO' and current_user.can_admin('SOPORTES USUARIOS') %}
             {{ topbar.button_previous('Tickets cancelados', url_for('soportes_tickets.list_cancel')) }}
         {% elif soporte_ticket.estado == 'CERRADO' %}
             {{ topbar.button_previous('Tickets cerrados', url_for('soportes_tickets.list_done')) }}

--- a/plataforma_web/blueprints/soportes_tickets/templates/soportes_tickets/list_user.jinja2
+++ b/plataforma_web/blueprints/soportes_tickets/templates/soportes_tickets/list_user.jinja2
@@ -1,0 +1,60 @@
+{% extends 'layouts/app.jinja2' %}
+{% import 'macros/list.jinja2' as list %}
+{% import 'macros/topbar.jinja2' as topbar %}
+
+{% block title %}Soportes Tickets{% endblock %}
+
+{% block topbar_actions %}
+    {% call topbar.page_buttons(titulo) %}
+        {% if current_user.can_insert('SOPORTES TICKETS') %}
+            {{ topbar.button_new('Nuevo Ticket', url_for('soportes_tickets.new')) }}
+        {% endif %}
+    {% endcall %}
+{% endblock %}
+
+{% block content %}
+    {% call list.card('Tickets') %}
+        <table id="soportes_tickets_datatable" class="table display nowrap" style="width:100%;">
+            <thead>
+                <tr>
+                    <th>ID</th>
+                    <th>Usuario</th>
+                    <th>Oficina</th>
+                    <th>Categoría</th>
+                    <th>Estado</th>
+                    <th>Descripción</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for ticket in tickets %}
+                {% if ticket.estado == "ABIERTO" %}
+                    <tr style="background-color:#fef9e7;">
+                {% elif ticket.estado == "TRABAJANDO" %}
+                    <tr style="background-color:#ebf5fb;">
+                {% elif ticket.estado == "CANCELADO" %}
+                    <tr style="background-color:#fdedec;">
+                {% elif ticket.estado == "NO RESUELTO" %}
+                    <tr style="background-color:#f5eef8 ;">
+                {% elif ticket.estado == "CERRADO" %}
+                    <tr style="background-color:#eafaf1;">
+                {% else %}
+                    <tr>
+                {% endif %}
+                    <td><a href="{{ url_for('soportes_tickets.detail', soporte_ticket_id=ticket.id) }}">{{ ticket.id }}</a></td>
+                    <td>{{ ticket.usuario.nombre | truncate(24) }}</td>
+                    <td>{{ ticket.usuario.oficina.clave }}</td>
+                    <td>{{ ticket.soporte_categoria.nombre | truncate(48) }}</td>
+                    <td>{{ ticket.estado }}</td>
+                    <td>{{ ticket.descripcion | truncate(48) }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    {% endcall %}
+{% endblock %}
+
+{% block custom_javascript %}
+    {{ list.datatable('soportes_tickets_datatable') }}
+    <!-- Refrescar esta página -->
+    <script> window.setTimeout(function () { window.location.reload(); }, 300000); </script>
+{% endblock %}

--- a/plataforma_web/blueprints/soportes_tickets/views.py
+++ b/plataforma_web/blueprints/soportes_tickets/views.py
@@ -140,7 +140,7 @@ def list_user():
     # Entregar
     return render_template(
         "soportes_tickets/list_user.jinja2",
-        tickets=tickets,
+        tickets=tickets.order_by(SoporteTicket.id.asc()).limit(100).all(),
         titulo="Tickets",
         estatus="A",
     )


### PR DESCRIPTION
Se hizo una vista más simplificada de tickets levantados por un usuario. Así como se verifica que este en su propia lista, y no edite, adjunte archivos o cancele otro ticket que no sean suyos.