### PR TITLE
Cambios realizados

### DIFF
--- a/plataforma_web/blueprints/soportes_categorias/templates/soportes_categorias/detail.jinja2
+++ b/plataforma_web/blueprints/soportes_categorias/templates/soportes_categorias/detail.jinja2
@@ -20,7 +20,12 @@
     {% call detail.card(estatus=soporte_categoria.estatus) %}
         {{ detail.label_value_big('Nombre', soporte_categoria.nombre) }}
         {{ detail.label_value('Atendido por', soporte_categoria.rol.nombre) }}
-        {{ detail.label_value('Instrucciones', soporte_categoria.instrucciones) }}
+        <div class="row">
+            <div class="col-md-3 text-end">Instrucciones</div>
+            <div class="col-md-9">
+                <pre>{{ soporte_categoria.instrucciones }}</pre>
+            </div>
+        </div>
     {% endcall %}
 {% endblock %}
 

--- a/plataforma_web/blueprints/soportes_categorias/views.py
+++ b/plataforma_web/blueprints/soportes_categorias/views.py
@@ -5,7 +5,7 @@ from flask import Blueprint, flash, redirect, render_template, url_for, request
 from flask_login import current_user, login_required
 
 from lib import datatables
-from lib.safe_string import safe_string, safe_message
+from lib.safe_string import safe_string, safe_message, safe_text
 
 from plataforma_web.blueprints.bitacoras.models import Bitacora
 from plataforma_web.blueprints.modulos.models import Modulo
@@ -71,7 +71,7 @@ def new():
             soporte_categoria = SoporteCategoria(
                 nombre=nombre,
                 rol=form.rol.data,
-                instrucciones=safe_string(form.instrucciones.data, max_len=2048),
+                instrucciones=safe_text(form.instrucciones.data, max_len=2048),
             )
             soporte_categoria.save()
             bitacora = Bitacora(
@@ -95,7 +95,7 @@ def edit(soporte_categoria_id):
     if form.validate_on_submit():
         soporte_categoria.nombre = safe_string(form.nombre.data)
         soporte_categoria.rol = form.rol.data
-        soporte_categoria.instrucciones = safe_string(form.instrucciones.data, max_len=2048)
+        soporte_categoria.instrucciones = safe_text(form.instrucciones.data, max_len=2048)
         soporte_categoria.save()
         bitacora = Bitacora(
             modulo=Modulo.query.filter_by(nombre=MODULO).first(),
@@ -161,7 +161,7 @@ def datatable_json():
         consulta = consulta.filter_by(estatus='A')
     if 'instrucciones' in request.form:
         consulta =  consulta.filter(SoporteCategoria.instrucciones != "")
-    registros = consulta.order_by(SoporteCategoria.nombre.desc()).offset(start).limit(rows_per_page).all()
+    registros = consulta.order_by(SoporteCategoria.nombre.asc()).offset(start).limit(rows_per_page).all()
     total = consulta.count()
     # Elaborar datos para DataTable
     data = []

--- a/plataforma_web/blueprints/soportes_tickets/forms.py
+++ b/plataforma_web/blueprints/soportes_tickets/forms.py
@@ -106,16 +106,8 @@ class SoporteTicketCancelForm(FlaskForm):
 class SoporteTicketSearchForm(FlaskForm):
     """Formulario de búsqueda de Ticekts"""
 
-    usuario = StringField("Usuario", validators=[Optional(), Length(max=256)])
-    fecha_inicio = DateField("Fecha de inicio", validators=[Optional()])
-    fecha_termino = DateField("Fecha de termino", validators=[Optional()])
-    categoria = QuerySelectField(
-        label="Categoría", query_factory=categorias_opciones, get_label="nombre", validators=[Optional()]
-    )
-    oficina = QuerySelectField(
-        label="Oficina", query_factory=oficinas_opciones, get_label="clave_nombre", validators=[Optional()]
-    )
-    tecnico = StringField("Técnico", validators=[Optional(), Length(max=256)])
+    fecha_desde = DateField("Creados desde", validators=[Optional()])
+    fecha_hasta = DateField("Creados hasta", validators=[Optional()])
     descripcion = StringField("Descripción", validators=[Optional(), Length(max=256)])
     solucion = StringField("Solución", validators=[Optional(), Length(max=256)])
     estado = SelectField("Estado", choices=SoporteTicket.ESTADOS, validators=[Optional()])

--- a/plataforma_web/blueprints/soportes_tickets/templates/soportes_tickets/list_search.jinja2
+++ b/plataforma_web/blueprints/soportes_tickets/templates/soportes_tickets/list_search.jinja2
@@ -19,8 +19,7 @@
             <thead>
                 <tr>
                     <th>ID</th>
-                    <th>Inicio</th>
-                    <th>Termino</th>
+                    <th>Tiempo de creación</th>
                     <th>Usuario</th>
                     <th>Oficina</th>
                     <th>Categoría</th>
@@ -54,8 +53,7 @@
             },
             columns: [
                 { data: "id" },
-                { data: "inicio" },
-                { data: "termino" },
+                { data: "creacion" },
                 { data: "usuario" },
                 { data: "oficina" },
                 { data: "categoria" },
@@ -73,18 +71,18 @@
                     }
                 },
                 {
-                    targets: 4,
+                    targets: 3,
                     data: null,
                     render: function(data, type, row, meta) {
                         return '<span title="' + data.nombre + '">' + data.clave + '</span>';
                     }
                 },
                 {
-                    targets: [5, 7, 8, 9],
+                    targets: [4, 6, 7, 8],
                     data: null,
                     render: function(data, type, row, meta) {
                         if (data != null)
-                            return (data.length > 32 ? data.substr(0, 32) + '…' : data);
+                            return (data.length > 28 ? data.substr(0, 28) + '…' : data);
                         return '—';
                     }
                 },

--- a/plataforma_web/blueprints/soportes_tickets/templates/soportes_tickets/search.jinja2
+++ b/plataforma_web/blueprints/soportes_tickets/templates/soportes_tickets/search.jinja2
@@ -16,12 +16,8 @@
 {% block content %}
     {% call f.card() %}
         {% call f.form_tag('soportes_tickets.search', fid='soportes_tickets_search_form') %}
-            {% call f.form_group(form.fecha_inicio) %}{% endcall %}
-            {% call f.form_group(form.fecha_termino) %}{% endcall %}
-            {% call f.form_group(form.usuario) %}{% endcall %}
-            {% call f.form_group(form.categoria) %}{% endcall %}
-            {% call f.form_group(form.oficina) %}{% endcall %}
-            {% call f.form_group(form.tecnico) %}{% endcall %}
+            {% call f.form_group(form.fecha_desde) %}{% endcall %}
+            {% call f.form_group(form.fecha_hasta) %}{% endcall %}
             {% call f.form_group(form.descripcion) %}{% endcall %}
             {% call f.form_group(form.solucion) %}{% endcall %}
             {% call f.form_group(form.estado) %}{% endcall %}
@@ -35,20 +31,6 @@
     <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
     <script>
         $(document).ready(function(){
-            $('#oficina').addClass('js-example-placeholder-single js-states form-control');
-            $("#oficina").prop("selectedIndex", -1);
-            $("#oficina").select2({
-                placeholder: "Oficina",
-                allowClear: true
-            });
-
-            $('#categoria').addClass('js-example-placeholder-single js-states form-control');
-            $("#categoria").prop("selectedIndex", -1);
-            $("#categoria").select2({
-                placeholder: "Categoría",
-                allowClear: true
-            });
-
             $("#estado").prepend($('<option>', {
                 value: '',
                 text: ''

--- a/plataforma_web/blueprints/soportes_tickets/views.py
+++ b/plataforma_web/blueprints/soportes_tickets/views.py
@@ -653,6 +653,7 @@ def recover(soporte_ticket_id):
 
 
 @soportes_tickets.route("/soportes_tickets/buscar", methods=["GET", "POST"])
+@permission_required(MODULO, Permiso.MODIFICAR)
 def search():
     """Buscar Tickets"""
     # revisar si es un funcionario o usuario


### PR DESCRIPTION
- Bloqueo del usuario normal del formulario de búsqueda de tickets
- Cambio de nombre en los campos de 'Creado desde' y 'Creados hasta'
- Quite los campos del formulario de búsquda: Categoría, Oficina, Usuario y Funcionario
- Mejora del query de descripción y solución
- Mejora de los query de usuario_id, funcionario_id y soportes_categorias_id
- Cambie la presentación de las instrucciones. Ahora están dentro de una etiqueta <pre>
- Quite algunas columnas del listado resultante de búsqueda: Fecha y hora de resolución