### PR TITLE
limpieza de codigo en soporte tickets detalles

### DIFF
--- a/plataforma_web/blueprints/soportes_tickets/templates/soportes_tickets/detail.jinja2
+++ b/plataforma_web/blueprints/soportes_tickets/templates/soportes_tickets/detail.jinja2
@@ -61,7 +61,7 @@
 {% block content %}
     {% call tabs.header() %}
         {{ tabs.button('detalles-tab', 'tab_detalles', 'Detalle', 'active') }}
-        {{ tabs.button('equipos-tab', 'tab_equipos', 'Equipos') }}
+        {{ tabs.button('inv-equipos-tab', 'tab_inv_equipos', 'Equipos') }}
         {{ tabs.button('archivo-adjunto-tab', 'tab_archivo_adjunto', 'Archivos adjuntos') }}
     {% endcall %}
     {% call tabs.content() %}
@@ -104,15 +104,15 @@
                 </div>
             {% endcall %}
         {% endcall %}
-        {% call tabs.div_content('tab_equipos', 'equipos-tab') %}
+        {% call tabs.div_content('tab_inv_equipos', 'inv-equipos-tab') %}
                 {% call detail.card('Equipos' ) %}
                     {% if current_user.can_view('INV EQUIPOS')  %}
                         <p class="mt-3"></p>
-                        <table id="inv_equipos_datatable" class="table {% if estatus == 'B'%}table-dark{% endif %} display nowrap" style="width:100%">
+                        <table id="inv_equipos_datatable" class="table display nowrap" style="width:100%">
                             <thead>
                                 <tr>
                                     <th>ID</th>
-                                    <th>Fecha de adquisición</th>
+                                    <th>Fecha de fabricación</th>
                                     <th>Tipo de equipo</th>
                                     <th>Marca</th>
                                     <th>Modelo</th>
@@ -178,12 +178,12 @@
     </script>
     {% if current_user.can_view('INV EQUIPOS') %}
         <script>
-        $('#equipos-tab').on('shown.bs.tab', function(){
+        $('#inv-equipos-tab').on('shown.bs.tab', function(){
             configDataTable['ajax']['url'] = '/inv_equipos/datatable_json';
             configDataTable['ajax']['data'] = { 'estatus': "A", 'usuario_id': {{ soporte_ticket.usuario.id}} };
             configDataTable['columns'] = [
                 { data: "detalle" },
-                { data: "adquisicion_fecha" },
+                { data: "fecha_fabricacion" },
                 { data: "tipo" },
                 { data: "inv_marca" },
                 { data: "inv_modelo" },
@@ -212,9 +212,7 @@
             ];
             $('#inv_equipos_datatable').DataTable().destroy();
             $('#inv_equipos_datatable').DataTable(configDataTable);
-
         });
-                { data: "adquisicion_fecha" },
         </script>
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
Se quito linea que estaba provocando que el datatables del detalle del ticket en la pestaña del equipo no lo mostrara correctamente - ya se probo