### PR TITLE
Colocar como opcional el campo datawarehouse_id

### DIFF
--- a/plataforma_web/blueprints/autoridades/forms.py
+++ b/plataforma_web/blueprints/autoridades/forms.py
@@ -55,7 +55,7 @@ class AutoridadEditForm(FlaskForm):
     directorio_listas_de_acuerdos = StringField("Directorio para listas de acuerdos", validators=[Optional(), Length(max=256)])
     directorio_sentencias = StringField("Directorio para sentencias", validators=[Optional(), Length(max=256)])
     limite_dias_listas_de_acuerdos = IntegerField("Límite días para listas de acuerdos", validators=[NumberRange(0, 30)])
-    datawarehouse_id = IntegerField("DataWareHouse ID")
+    datawarehouse_id = IntegerField("DataWareHouse ID", validators=[Optional()])
     guardar = SubmitField("Guardar")
 
 


### PR DESCRIPTION
Olvidé colocar como opcional el campo de datawarehouse_id en el formulario de edición. No creo que sea conveniente rellenarlo con 0 cuando no se utiliza, lo mejor es que se quede como vacío.