### PR TITLE
Cambios de hora en otras vistas de Audiencias

### DIFF
--- a/plataforma_web/blueprints/audiencias/templates/audiencias/list.jinja2
+++ b/plataforma_web/blueprints/audiencias/templates/audiencias/list.jinja2
@@ -58,7 +58,6 @@
                     targets: 0,
                     type: "date",
                     render: function (data, type, row) {
-                        //return moment.utc(data).local().format("YYYY-MM-DD HH:mm:ss");
                         return data;
                     }
                 },

--- a/plataforma_web/blueprints/audiencias/templates/audiencias/list_generica.jinja2
+++ b/plataforma_web/blueprints/audiencias/templates/audiencias/list_generica.jinja2
@@ -64,7 +64,7 @@
                     targets: 0,
                     data: null,
                     render: function(data, type, row, meta) {
-                        return '<a href="' + data.url + '">' + moment.utc(data.tiempo).local().format("YYYY-MM-DD HH:mm:ss") + '</a>';
+                        return '<a href="' + data.url + '">' + data.tiempo + '</a>';
                     }
                 },
                 {

--- a/plataforma_web/blueprints/audiencias/templates/audiencias/list_sape.jinja2
+++ b/plataforma_web/blueprints/audiencias/templates/audiencias/list_sape.jinja2
@@ -70,7 +70,7 @@
                     targets: 0,
                     data: null,
                     render: function(data, type, row, meta) {
-                        return '<a href="' + data.url + '">' + moment.utc(data.tiempo).local().format("YYYY-MM-DD HH:mm:ss") + '</a>';
+                        return '<a href="' + data.url + '">' + data.tiempo + '</a>';
                     }
                 },
                 {


### PR DESCRIPTION
Todavía quedaban listados con las horas un UTC que nos estaban reportando.
Estas deberían ser las últimas que quedaron pendientes.