### PR TITLE
Ricval/archivo correcciones

### DIFF
--- a/lib/safe_string.py
+++ b/lib/safe_string.py
@@ -49,6 +49,8 @@ def safe_expediente(input_str):
     if not isinstance(input_str, str) or input_str.strip() == "":
         return ""
     elementos = re.sub(r"[^a-zA-Z0-9]+", "|", unidecode(input_str)).split("|")
+    if len(elementos) != 2:
+        raise ValueError("Número de elementos incorrecto")
     try:
         numero = int(elementos[0])
         ano = int(elementos[1])

--- a/plataforma_web/blueprints/arc_documentos/views.py
+++ b/plataforma_web/blueprints/arc_documentos/views.py
@@ -190,7 +190,7 @@ def new():
         elif anio < 1950 or anio > date.today().year:
             flash(f"El Año debe ser una fecha entre 1950 y el año actual {date.today().year}", "warning")
         elif num_expediente is None:
-            flash("El número de expediente no es válido", "warning")
+            flash("El número de expediente no es válido. El formato esperado es (número/año) (999/2023)", "warning")
         else:
 
             documento = ArcDocumento(

--- a/plataforma_web/blueprints/arc_remesas_documentos/templates/arc_remesas_documentos/print_list.jinja2
+++ b/plataforma_web/blueprints/arc_remesas_documentos/templates/arc_remesas_documentos/print_list.jinja2
@@ -83,7 +83,7 @@
                 <tr>
                     <td>{{ documento.id }}</td>
                     <td>{{ documento.arc_documento.expediente }}</td>
-                    <td>{{ documento.arc_documento.arc_juzgado_origen.nombre }}</td>
+                    <td>{{ documento.arc_documento.arc_juzgado_origen.clave }}</td>
                     <td><strong>Actor:</strong> {{ documento.arc_documento.actor }}<br>
                         <strong>Demandado:</strong> {{ documento.arc_documento.demandado }}
                     </td>

--- a/plataforma_web/blueprints/arc_remesas_documentos/views.py
+++ b/plataforma_web/blueprints/arc_remesas_documentos/views.py
@@ -76,8 +76,8 @@ def datatable_json():
                 "tipo": resultado.arc_documento.tipo,
                 "juicio": resultado.arc_documento.juicio,
                 "juzgado_origen": {
-                    "clave": resultado.arc_documento.arc_juzgado_origen.clave if resultado.arc_documento.arc_juzgado_origen_id is not None else None,
-                    "nombre": resultado.arc_documento.arc_juzgado_origen.descripcion_corta if resultado.arc_documento.arc_juzgado_origen_id is not None else None,
+                    "clave": resultado.arc_documento.arc_juzgado_origen.clave if resultado.arc_documento.arc_juzgado_origen_id is not None else "",
+                    "nombre": resultado.arc_documento.arc_juzgado_origen.descripcion_corta if resultado.arc_documento.arc_juzgado_origen_id is not None else "",
                 },
                 "fojas": {
                     "nuevas": resultado.fojas,

--- a/plataforma_web/blueprints/arc_solicitudes/views.py
+++ b/plataforma_web/blueprints/arc_solicitudes/views.py
@@ -364,7 +364,7 @@ def new(documento_id):
     form.demandado.data = documento.demandado
     form.juicio.data = documento.juicio
     form.tipo_juzgado.data = documento.tipo_juzgado
-    form.juzgado_origen.data = documento.arc_juzgado_origen.nombre
+    form.juzgado_origen.data = documento.arc_juzgado_origen.nombre if documento.arc_juzgado_origen is not None else ""
     form.tipo.data = documento.tipo
     form.fojas_actuales.data = documento.fojas
     form.ubicacion.data = documento.ubicacion


### PR DESCRIPTION
- Se mejoró el ingreso del número de expediente. `safe_expediente()`
- Se corrigió cuando no se ingresa un juzgado de origen a un expediente nuevo. Anterior marcaba un erro 500
- Se mejoró la vista cuando un juzgado de origen no está indicado. paso de mostrar `null` a dejar el campo en vacío.