### PR TITLE
Cambio de orden en el listado de los expedientes

### DIFF
--- a/plataforma_web/blueprints/arc_documentos/views.py
+++ b/plataforma_web/blueprints/arc_documentos/views.py
@@ -76,7 +76,7 @@ def datatable_json():
     if "juzgado_id" in request.form:
         consulta = consulta.filter_by(autoridad_id=int(request.form["juzgado_id"]))
     # Ordena los registros resultantes por id descendientes para ver los más recientemente capturados
-    registros = consulta.order_by(ArcDocumento.id.desc()).offset(start).limit(rows_per_page).all()
+    registros = consulta.order_by(ArcDocumento.anio).order_by(ArcDocumento.expediente).offset(start).limit(rows_per_page).all()
     total = consulta.count()
     # Elaborar datos para DataTable
     data = []


### PR DESCRIPTION
Se pidió que el orden de los expedientes en el módulo de Archivo fuera 999/YYYY de menor a mayor.