### PR TITLE
Ricval/remesas tipos docs

### DIFF
--- a/plataforma_web/blueprints/arc_archivos/templates/arc_archivos/list_archivista.jinja2
+++ b/plataforma_web/blueprints/arc_archivos/templates/arc_archivos/list_archivista.jinja2
@@ -112,13 +112,8 @@
                     </div>
                     <div class="col-4">
                         <div class="form-floating">
-                            <select class="form-select" id="tipoDocumentoSelect_remesa" name="tipoDocumentoSelect_remesa" onchange="filtros_remesas.buscar(); return false;" style="flex: inherit;">
-                                <option selected value=""></option>
-                                {% for tipo_documento in tipos_documentos_remesas %}
-                                    <option value="{{tipo_documento}}">{{tipo_documento}}</option>
-                                {% endfor %}
-                            </select>
-                            <label for="tipoDocumentoSelect_remesa">Tipo de Documentos</label>
+                            <select id="tipoDocumentoInput_remesa" class="form-control js-select2-filter" onchange="filtros_remesas.buscar(); return false;" style="text-transform: uppercase"></select>
+                            <label for="tipoDocumentoInput_remesa">Tipo de Documento</label>
                         </div>
                     </div>
                     <div class="col-4">
@@ -318,7 +313,7 @@
         // Añadimos los difrentes inputs utilizados
         filtros_remesas.add_input('idInput_remesa', 'remesa_id');
         filtros_remesas.add_input('anioInput_remesa', 'anio');
-        filtros_remesas.add_input('tipoDocumentoSelect_remesa', 'tipo_documento');
+        filtros_remesas.add_input('tipoDocumentoInput_remesa', 'arc_documento_tipo_id');
         filtros_remesas.add_input('numOficioInput_remesa', 'num_oficio');
         filtros_remesas.add_input('juzgadoInput_remesa', 'juzgado_id');
         filtros_remesas.add_input('estadoSelect_remesa', 'estado');
@@ -373,6 +368,26 @@
                 },
                 minimumInputLength: 3,
                 cache: false
+            });
+            // ---
+            $(document).ready(function(){
+                $('#tipoDocumentoInput_remesa').addClass('js-example-placeholder-single');
+                $("#tipoDocumentoInput_remesa").select2({
+                    // --- Carga de emails por Ajax --- //
+                    ajax: {
+                        url: '/arc_documentos_tipos/tipos_documentos_json',
+                        headers: { "X-CSRF-TOKEN": "{{ csrf_token() }}" },
+                        dataType: 'json',
+                        delay: 250,
+                        type: "POST",
+                        data: function (params) {
+                            return { 'nombre': params.term.toUpperCase() };
+                        }
+                    },
+                    placeholder: "",
+                    minimumInputLength: 1,
+                    allowClear: true
+                });
             });
         });
     </script>

--- a/plataforma_web/blueprints/arc_archivos/templates/arc_archivos/list_jefe_remesa.jinja2
+++ b/plataforma_web/blueprints/arc_archivos/templates/arc_archivos/list_jefe_remesa.jinja2
@@ -167,13 +167,8 @@
                     </div>
                     <div class="col-3">
                         <div class="form-floating">
-                            <select class="form-select" id="tipoDocumentoSelect_remesa" name="tipoDocumentoSelect_remesa" onchange="filtros_remesas.buscar(); return false;" style="flex: inherit;">
-                                <option selected value=""></option>
-                                {% for tipo_documento in tipos_documentos_remesas %}
-                                    <option value="{{tipo_documento}}">{{tipo_documento}}</option>
-                                {% endfor %}
-                            </select>
-                            <label for="tipoDocumentoSelect_remesa">Tipo de Documentos</label>
+                            <select id="tipoDocumentoInput_remesa" class="form-control js-select2-filter" onchange="filtros_remesas.buscar(); return false;" style="text-transform: uppercase"></select>
+                            <label for="tipoDocumentoInput_remesa">Tipo de Documento</label>
                         </div>
                     </div>
                     <div class="col-3">
@@ -400,7 +395,7 @@
         // Añadimos los difrentes inputs utilizados
         filtros_remesas.add_input('idInput_remesa', 'remesa_id');
         filtros_remesas.add_input('anioInput_remesa', 'anio');
-        filtros_remesas.add_input('tipoDocumentoSelect_remesa', 'tipo_documento');
+        filtros_remesas.add_input('tipoDocumentoInput_remesa', 'arc_documento_tipo_id');
         filtros_remesas.add_input('numOficioInput_remesa', 'num_oficio');
         filtros_remesas.add_input('juzgadoInput_remesa', 'juzgado_id');
         filtros_remesas.add_input('asignadoInput_remesa', 'asignado_id');
@@ -487,6 +482,26 @@
                 },
                 minimumInputLength: 3,
                 cache: false
+            });
+            // ---
+            $(document).ready(function(){
+                $('#tipoDocumentoInput_remesa').addClass('js-example-placeholder-single');
+                $("#tipoDocumentoInput_remesa").select2({
+                    // --- Carga de emails por Ajax --- //
+                    ajax: {
+                        url: '/arc_documentos_tipos/tipos_documentos_json',
+                        headers: { "X-CSRF-TOKEN": "{{ csrf_token() }}" },
+                        dataType: 'json',
+                        delay: 250,
+                        type: "POST",
+                        data: function (params) {
+                            return { 'nombre': params.term.toUpperCase() };
+                        }
+                    },
+                    placeholder: "",
+                    minimumInputLength: 1,
+                    allowClear: true
+                });
             });
         });
     </script>

--- a/plataforma_web/blueprints/arc_archivos/templates/arc_archivos/list_solicitante.jinja2
+++ b/plataforma_web/blueprints/arc_archivos/templates/arc_archivos/list_solicitante.jinja2
@@ -5,6 +5,9 @@
 {% block title %}Archivo{% endblock %}
 
 {% block custom_head %}
+    <!-- Select2 bootstrap -->
+    <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
+    <link href="https://storage.googleapis.com/pjecz-informatica/static/css/select2.css" rel="stylesheet" />
     <style>
     .bg-pink {
         color: white;
@@ -46,22 +49,22 @@
         <!-- Formulario de filtros -->
         <div class="row">
             <div class="col">
-                <form class="row g-1 mb-3" id="buscadorForm" onsubmit="buscar_solicitud(); return false;" autocomplete="off">
+                <form class="row g-1 mb-3" id="buscadorForm" onsubmit="filtros_solicitudes.buscar(); return false;" autocomplete="off">
                     <div class="col-2">
                         <div class="form-floating">
-                            <input id="idInput_solicitud" type="text" class="form-control" aria-label="ID" onchange="buscar_solicitud(); return false;">
+                            <input id="idInput_solicitud" type="text" class="form-control" aria-label="ID" onchange="filtros_solicitudes.buscar(); return false;">
                             <label for="idInput_solicitud">ID</label>
                         </div>
                     </div>
                     <div class="col-4">
                         <div class="form-floating">
-                            <input id="documentoInput_solicitud" type="text" class="form-control" aria-label="Documento" onchange="buscar_solicitud(); return false;">
+                            <input id="documentoInput_solicitud" type="text" class="form-control" aria-label="Documento" onchange="filtros_solicitudes.buscar(); return false;">
                             <label for="documentoInput_solicitud">Documento</label>
                         </div>
                     </div>
                     <div class="col-4">
                         <div class="form-floating">
-                            <select class="form-select" id="estadoSelect_solicitud" name="estadoSelect_solicitud" aria-label="Estado" onchange="buscar_solicitud(); return false;" style="flex: inherit;">
+                            <select class="form-select" id="estadoSelect_solicitud" name="estadoSelect_solicitud" aria-label="Estado" onchange="filtros_solicitudes.buscar(); return false;" style="flex: inherit;">
                                 <option selected value=""></option>
                                 {% for estado in estados_solicitudes %}
                                     <option value="{{estado}}">{{estado}}</option>
@@ -71,8 +74,8 @@
                         </div>
                     </div>
                     <div class="col-2 text-end">
-                        <button title="Buscar" class="btn btn-primary btn-lg" onclick="buscar_solicitud(); return false;" id="button-buscar"><span class="iconify" data-icon="mdi:magnify"></span></button>
-                        <button title="Limpiar" class="btn btn-warning btn-lg" type="reset" onclick="limpiar_solicitud();" id="button-limpiar"><span class="iconify" data-icon="mdi:broom"></span></button>
+                        <button title="Buscar" class="btn btn-primary btn-lg" onclick="filtros_solicitudes.buscar(); return false;" id="button-buscar"><span class="iconify" data-icon="mdi:magnify"></span></button>
+                        <button title="Limpiar" class="btn btn-warning btn-lg" type="reset" onclick="filtros_solicitudes.limpiar();" id="button-limpiar"><span class="iconify" data-icon="mdi:broom"></span></button>
                     </div>
                 </form>
             </div>
@@ -98,39 +101,34 @@
     <!-- Formulario de filtros REMESA -->
         <div class="row">
             <div class="col">
-                <form class="row g-1 mb-3" id="buscadorForm" onsubmit="buscar_remesa(); return false;" autocomplete="off">
+                <form class="row g-1 mb-3" id="buscadorForm" onsubmit="filtros_remesas.buscar(); return false;" autocomplete="off">
                     <div class="col-4">
                         <div class="form-floating">
-                            <input id="idInput_remesa" type="text" class="form-control" onchange="buscar_remesa(); return false;">
+                            <input id="idInput_remesa" type="text" class="form-control" onchange="filtros_remesas.buscar(); return false;">
                             <label for="idInput_remesa">ID</label>
                         </div>
                     </div>
                     <div class="col-4">
                         <div class="form-floating">
-                            <input id="anioInput_remesa" type="text" class="form-control" onchange="buscar_remesa(); return false;">
+                            <input id="anioInput_remesa" type="text" class="form-control" onchange="filtros_remesas.buscar(); return false;">
                             <label for="anioInput_remesa">Año</label>
                         </div>
                     </div>
                     <div class="col-4">
                         <div class="form-floating">
-                            <select class="form-select" id="tipoDocumentoSelect_remesa" name="tipoSelect" onchange="buscar_remesa(); return false;" style="flex: inherit;">
-                                <option selected value=""></option>
-                                {% for tipo_documento in tipos_documentos_remesas %}
-                                    <option value="{{tipo_documento}}">{{tipo_documento}}</option>
-                                {% endfor %}
-                            </select>
-                            <label for="tipoDocumentoSelect_remesa">Tipo de Documentos</label>
+                            <select id="tipoDocumentoInput_remesa" class="form-control js-select2-filter" onchange="filtros_remesas.buscar(); return false;" style="text-transform: uppercase"></select>
+                            <label for="tipoDocumentoInput_remesa">Tipo de Documento</label>
                         </div>
                     </div>
                     <div class="col-4">
                         <div class="form-floating">
-                            <input id="numOficioInput_remesa" type="text" class="form-control" onchange="buscar_remesa(); return false;">
+                            <input id="numOficioInput_remesa" type="text" class="form-control" onchange="filtros_remesas.buscar(); return false;">
                             <label for="numOficioInput_remesa">Núm. Oficio</label>
                         </div>
                     </div>
                     <div class="col-4">
                         <div class="form-floating">
-                            <select class="form-select" id="estadoSelect_remesa" name="estadoSelect_remesa" aria-label="Estado" onchange="buscar_remesa(); return false;" style="flex: inherit;">
+                            <select class="form-select" id="estadoSelect_remesa" name="estadoSelect_remesa" aria-label="Estado" onchange="filtros_remesas.buscar(); return false;" style="flex: inherit;">
                                 <option selected value=""></option>
                                 {% for estado in estados_remesas %}
                                     <option value="{{estado}}">{{estado}}</option>
@@ -140,8 +138,8 @@
                         </div>
                     </div>
                     <div class="col-4 text-end">
-                        <button title="Buscar" class="btn btn-primary btn-lg" onclick="buscar_remesa(); return false;" id="button-buscar"><span class="iconify" data-icon="mdi:magnify"></span></button>
-                        <button title="Limpiar" class="btn btn-warning btn-lg" type="reset" onclick="limpiar_remesa();" id="button-limpiar"><span class="iconify" data-icon="mdi:broom"></span></button>
+                        <button title="Buscar" class="btn btn-primary btn-lg" onclick="filtros_remesas.buscar(); return false;" id="button-buscar"><span class="iconify" data-icon="mdi:magnify"></span></button>
+                        <button title="Limpiar" class="btn btn-warning btn-lg" type="reset" onclick="filtros_remesas.limpiar();" id="button-limpiar"><span class="iconify" data-icon="mdi:broom"></span></button>
                     </div>
                 </form>
             </div>
@@ -164,17 +162,22 @@
 {% endblock %}
 
 {% block custom_javascript %}
-    {{ list.config_datatable() }}
+    <!-- Importación de la configuración para DataTables -->
+    <script src="/static/js/datatables_config.js"></script>
+    <!-- Importación de los fitlros para dataTable -->
+    <script src="/static/js/datatables_filtros.js"></script>
     <script>
-        configDataTable['ajax']['url'] = '/arc_solicitudes/datatable_json';
-        configDataTable['ajax']['data'] = {{ filtros_solicitudes }};
-        configDataTable['columns'] = [
+        const dataTable_funcs_solicitudes = new ConfigDataTable( "{{ csrf_token() }}" );
+        let configDataTable_solicitudes = dataTable_funcs_solicitudes.config;
+        configDataTable_solicitudes['ajax']['url'] = '/arc_solicitudes/datatable_json';
+        configDataTable_solicitudes['ajax']['data'] = {{ filtros_solicitudes }};
+        configDataTable_solicitudes['columns'] = [
             { data: 'solicitud' },
             { data: 'tiempo' },
             { data: 'documento' },
             { data: 'estado' }
         ];
-        configDataTable['columnDefs'] = [
+        configDataTable_solicitudes['columnDefs'] = [
             {
                 targets: 0, // id
                 data: null,
@@ -213,7 +216,7 @@
                 }
             }
         ];
-        configDataTable['rowCallback'] = function(row, data) {
+        configDataTable_solicitudes['rowCallback'] = function(row, data) {
             switch (data.estado)    {
                 case "SOLICITADO":      $(row).css("background-color", "#fef9e7");  break;
                 case "ASIGNADO":        $(row).css("background-color", "#ebf5fb");  break;
@@ -224,104 +227,23 @@
                 case "ENTREGADO":       $(row).css("background-color", "#d1e7dd");  break;
             }
         };
-
-        // Búsqueda
-        let id = document.getElementById('idInput_solicitud').value;
-        let documento = document.getElementById('documentoInput_solicitud').value;
-        let estado = document.getElementById('estadoSelect_solicitud').value;
-
-        if(id != '')
-            configDataTable['ajax']['data']['solicitud_id'] = id;
-        if(documento != '')
-            configDataTable['ajax']['data']['expediente'] = documento;
-        if(estado != '')
-            configDataTable['ajax']['data']['estado'] = estado;
-
-        // Datatable
-        $('#arc_solicitudes_datatable').DataTable(configDataTable);
-    </script>
-    <!-- Función de buscador solicitudes -->
-    <script type="text/javascript">
-        function buscar_solicitud() {
-            let id = document.getElementById('idInput_solicitud').value;
-            let documento = document.getElementById('documentoInput_solicitud').value;
-            let estado = document.getElementById('estadoSelect_solicitud').value;
-
-            if( configDataTable['ajax']['data']['solicitud_id'] === undefined && id === '' &&
-                configDataTable['ajax']['data']['expediente'] === undefined && documento === '' &&
-                configDataTable['ajax']['data']['estado'] === undefined && estado === ''
-            ) return false;
-
-            $('#arc_solicitudes_datatable').DataTable().destroy();
-
-            if(id == '')
-                delete configDataTable['ajax']['data']['solicitud_id'];
-            else
-                configDataTable['ajax']['data']['solicitud_id'] = id;
-            if(documento == '')
-                delete configDataTable['ajax']['data']['expediente'];
-            else
-                configDataTable['ajax']['data']['expediente'] = documento;
-            if(estado == '')
-                delete configDataTable['ajax']['data']['estado'];
-            else
-                configDataTable['ajax']['data']['estado'] = estado;
-
-            $('#arc_solicitudes_datatable').DataTable(configDataTable);
-        };
-
-        function limpiar_solicitud()  {
-            if( configDataTable['ajax']['data']['solicitud_id'] === undefined &&
-                configDataTable['ajax']['data']['expediente'] === undefined &&
-                configDataTable['ajax']['data']['estado'] === undefined
-            ) return false;
-            
-            delete configDataTable['ajax']['data']['solicitud_id'];
-            delete configDataTable['ajax']['data']['expediente'];
-            delete configDataTable['ajax']['data']['estado'];
-
-            $('#arc_solicitudes_datatable').DataTable().destroy();
-            $('#arc_solicitudes_datatable').DataTable(configDataTable);
-        };
+        // Declaración de los Filtros utilizados
+        // Creación del Objeto manejador de Filtros
+        const filtros_solicitudes = new Filtros('#arc_solicitudes_datatable', configDataTable_solicitudes);
+        // Añadimos los difrentes inputs utilizados
+        filtros_solicitudes.add_input('idInput_solicitud', 'solicitud_id');
+        filtros_solicitudes.add_input('documentoInput_solicitud', 'expediente');
+        filtros_solicitudes.add_input('estadoSelect_solicitud', 'estado');
+        // Precarga de los valores de los inputs mantenidos después de la carga de la página.
+        filtros_solicitudes.precarga();
     </script>
     <!-- DataTable para Remesas -->
     <script>
-        let configDataTable_2 = {
-            processing: true,
-            serverSide: true,
-            ordering: false,
-            searching: false,
-            responsive: true,
-            scrollX: true,
-            ajax: {
-                url: null,
-                type: "POST",
-                headers: { "X-CSRF-TOKEN": "{{ csrf_token() }}" },
-                dataType: "json",
-                dataSrc: "data",
-                data: null
-            },
-            columns: null,
-            columnDefs: null,
-            language: {
-                lengthMenu: "Mostrar _MENU_",
-                search: "Filtrar:",
-                zeroRecords: "No se encontraron registros",
-                info: "Total de registros _TOTAL_ ",
-                infoEmpty: "No hay registros",
-                infoFiltered: "(_TOTAL_ filtrados de _MAX_ registros)",
-                oPaginate: {
-                    sFirst: "Primero",
-                    sLast: "Último",
-                    sNext: "Siguiente",
-                    sPrevious: "Anterior"
-                }
-            }
-        };
-        // ---
-        configDataTable_2['ajax']['url'] = '/arc_remesas/datatable_json';
-        configDataTable_2['ajax']['data'] = {{ filtros_remesas }};
-        configDataTable_2['columns'] = [
+        const dataTable_funcs_remesas = new ConfigDataTable( "{{ csrf_token() }}" );
+        let configDataTable_remesas = dataTable_funcs_remesas.config;
+        configDataTable_remesas['ajax']['url'] = '/arc_remesas/datatable_json';
+        configDataTable_remesas['ajax']['data'] = {{ filtros_remesas }};
+        configDataTable_remesas['columns'] = [
             { data: 'remesa' },
             { data: 'tiempo' },
             { data: 'anio' },
@@ -330,7 +252,7 @@
             { data: 'num_docs' },
             { data: 'estado' }
         ];
-        configDataTable_2['columnDefs'] = [
+        configDataTable_remesas['columnDefs'] = [
             {
                 targets: 0, // id
                 data: null,
@@ -364,7 +286,7 @@
                 }
             }
         ];
-        configDataTable_2['rowCallback'] = function(row, data) {
+        configDataTable_remesas['rowCallback'] = function(row, data) {
             switch (data.estado)    {
                 case "PENDIENTE":       $(row).css("background-color", "#fef9e7");  break;
                 case "CANCELADO":       $(row).css("background-color", "#eeeeee");  break;
@@ -376,87 +298,17 @@
                 case "ARCHIVADO CON ANOMALIA": $(row).css("background-color", "#d2f4ea");  break;
             }
         };
-
-        // Búsqueda
-        let id_remesa = document.getElementById('idInput_remesa').value;
-        let anio = document.getElementById('anioInput_remesa').value;
-        let tipo_documento = document.getElementById('tipoDocumentoSelect_remesa').value;
-        let num_oficio = document.getElementById('numOficioInput_remesa').value;
-        let estado_remesa = document.getElementById('estadoSelect_remesa').value;
-
-        if(id_remesa != '')
-            configDataTable_2['ajax']['data']['remesa_id'] = id_remesa;
-        if(anio != '')
-            configDataTable_2['ajax']['data']['anio'] = anio;
-        if(tipo_documento != '')
-            configDataTable_2['ajax']['data']['tipo_documento'] = tipo_documento;
-        if(num_oficio != '')
-            configDataTable_2['ajax']['data']['num_oficio'] = num_oficio;
-        if(estado_remesa != '')
-            configDataTable_2['ajax']['data']['estado'] = estado_remesa;
-
-        // Datatable
-        $('#arc_remesas_datatable').DataTable(configDataTable_2);
-    </script>
-    <!-- Función de buscador remesas -->
-    <script type="text/javascript">
-        function buscar_remesa() {
-            let id = document.getElementById('idInput_remesa').value;
-            let anio = document.getElementById('anioInput_remesa').value;
-            let tipo_documento = document.getElementById('tipoDocumentoSelect_remesa').value;
-            let num_oficio = document.getElementById('numOficioInput_remesa').value;
-            let estado = document.getElementById('estadoSelect_remesa').value;
-
-            if( configDataTable_2['ajax']['data']['remesa_id'] === undefined && id === '' &&
-                configDataTable_2['ajax']['data']['anio'] === undefined && anio === '' &&
-                configDataTable_2['ajax']['data']['tipo_documento'] === undefined && tipo_documento === '' &&
-                configDataTable_2['ajax']['data']['num_oficio'] === undefined && num_oficio === '' &&
-                configDataTable_2['ajax']['data']['estado'] === undefined && estado === ''
-            ) return false;
-
-            $('#arc_remesas_datatable').DataTable().destroy();
-
-            if(id == '')
-                delete configDataTable_2['ajax']['data']['remesa_id'];
-            else
-                configDataTable_2['ajax']['data']['remesa_id'] = id;
-            if(anio == '')
-                delete configDataTable_2['ajax']['data']['anio'];
-            else
-                configDataTable_2['ajax']['data']['anio'] = anio;
-            if(tipo_documento == '')
-                delete configDataTable_2['ajax']['data']['tipo_documento'];
-            else
-                configDataTable_2['ajax']['data']['tipo_documento'] = tipo_documento;
-            if(num_oficio == '')
-                delete configDataTable_2['ajax']['data']['num_oficio'];
-            else
-                configDataTable_2['ajax']['data']['num_oficio'] = num_oficio;
-            if(estado == '')
-                delete configDataTable_2['ajax']['data']['estado'];
-            else
-                configDataTable_2['ajax']['data']['estado'] = estado;
-
-            $('#arc_remesas_datatable').DataTable(configDataTable_2);
-        };
-
-        function limpiar_remesa()  {
-            if( configDataTable_2['ajax']['data']['remesa_id'] === undefined &&
-                configDataTable_2['ajax']['data']['anio'] === undefined &&
-                configDataTable_2['ajax']['data']['tipo_documento'] === undefined &&
-                configDataTable_2['ajax']['data']['num_oficio'] === undefined &&
-                configDataTable_2['ajax']['data']['estado'] === undefined
-            ) return false;
-            
-            delete configDataTable_2['ajax']['data']['remesa_id'];
-            delete configDataTable_2['ajax']['data']['anio'];
-            delete configDataTable_2['ajax']['data']['tipo_documento'];
-            delete configDataTable_2['ajax']['data']['num_oficio'];
-            delete configDataTable_2['ajax']['data']['estado'];
-
-            $('#arc_remesas_datatable').DataTable().destroy();
-            $('#arc_remesas_datatable').DataTable(configDataTable_2);
-        };
+        // Declaración de los Filtros utilizados
+        // Creación del Objeto manejador de Filtros
+        const filtros_remesas = new Filtros('#arc_remesas_datatable', configDataTable_remesas);
+        // Añadimos los difrentes inputs utilizados
+        filtros_remesas.add_input('idInput_remesa', 'remesa_id');
+        filtros_remesas.add_input('anioInput_remesa', 'anio');
+        filtros_remesas.add_input('tipoDocumentoInput_remesa', 'arc_documento_tipo_id');
+        filtros_remesas.add_input('numOficioInput_remesa', 'num_oficio');
+        filtros_remesas.add_input('estadoSelect_remesa', 'estado');
+        // Precarga de los valores de los inputs mantenidos después de la carga de la página.
+        filtros_remesas.precarga();
     </script>
     <!-- Mostar historial -->
     {% if mostrando_historial %}
@@ -465,4 +317,28 @@
         $('.card-header').addClass('bg-dark text-light');
     </script>
     {% endif %}
+    <!-- Select2 bootstrap -->
+    <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
+    <script>
+        // Select2 para Juzgado Filtro Solicitudes
+        $(document).ready(function(){
+            $('#tipoDocumentoInput_remesa').addClass('js-example-placeholder-single');
+            $("#tipoDocumentoInput_remesa").select2({
+                // --- Carga de emails por Ajax --- //
+                ajax: {
+                    url: '/arc_documentos_tipos/tipos_documentos_json',
+                    headers: { "X-CSRF-TOKEN": "{{ csrf_token() }}" },
+                    dataType: 'json',
+                    delay: 250,
+                    type: "POST",
+                    data: function (params) {
+                        return { 'nombre': params.term.toUpperCase() };
+                    }
+                },
+                placeholder: "",
+                minimumInputLength: 1,
+                allowClear: true
+            });
+        });
+    </script>
 {% endblock %}

--- a/plataforma_web/blueprints/arc_archivos/views.py
+++ b/plataforma_web/blueprints/arc_archivos/views.py
@@ -47,13 +47,12 @@ def list_active():
     if current_user.can_admin(MODULO):
         return render_template(
             "arc_archivos/list_jefe_remesa.jinja2",
-            filtros_solicitudes=json.dumps({"estatus": "A", "omitir_archivados": True}),
-            filtros_remesas=json.dumps({"estatus": "A", "omitir_archivados": True}),
+            filtros_solicitudes=json.dumps({"estatus": "A", "omitir_archivados": True, "omitir_cancelados": True}),
+            filtros_remesas=json.dumps({"estatus": "A", "omitir_archivados": True, "omitir_cancelados": True}),
             estatus="A",
             titulo="Archivo - Bandeja de Entrada 📥",
             estados_solicitudes=ArcSolicitud.ESTADOS,
             estados_remesas=ArcRemesa.ESTADOS,
-            tipos_documentos_remesas=ArcRemesa.TIPOS_DOCUMENTOS,
             rol_archivista=ROL_ARCHIVISTA,
             mostrar_btn_local_global=mostrar_btn_local,
         )
@@ -66,9 +65,8 @@ def list_active():
             titulo="Archivo - Bandeja de Entrada 📥",
             estados_solicitudes=ArcSolicitud.ESTADOS,
             estados_remesas=ArcRemesa.ESTADOS,
-            tipos_documentos_remesas=ArcRemesa.TIPOS_DOCUMENTOS,
         )
-    if ROL_JEFE_REMESA in current_user_roles:
+    if ROL_JEFE_REMESA in current_user_roles or ROL_JEFE_REMESA_ADMINISTRADOR in current_user_roles:
         return render_template(
             "arc_archivos/list_jefe_remesa.jinja2",
             filtros_solicitudes=json.dumps({"estatus": "A", "omitir_archivados": True, "omitir_cancelados": True, "distrito_id": current_user.autoridad.distrito_id}),
@@ -77,7 +75,6 @@ def list_active():
             titulo="Archivo - Bandeja de Entrada 📥",
             estados_solicitudes=ArcSolicitud.ESTADOS,
             estados_remesas=ArcRemesa.ESTADOS,
-            tipos_documentos_remesas=ArcRemesa.TIPOS_DOCUMENTOS,
             rol_archivista=ROL_ARCHIVISTA,
             mostrar_btn_local_global=mostrar_btn_local,
         )
@@ -90,18 +87,17 @@ def list_active():
             titulo="Archivo - Bandeja de Entrada 📥",
             estados_solicitudes=ArcSolicitud.ESTADOS,
             estados_remesas=ArcRemesa.ESTADOS,
-            tipos_documentos_remesas=ArcRemesa.TIPOS_DOCUMENTOS,
             rol_archivista=ROL_ARCHIVISTA,
         )
     # Por defecto
     return render_template(
         "arc_archivos/list.jinja2",
-        filtros=json.dumps({"estatus": "A", "omitir_archivados": True, "juzgado_id": current_user.autoridad.id}),
+        filtros_solicitudes=json.dumps({"estatus": "A", "omitir_archivados": True, "juzgado_id": current_user.autoridad.id}),
+        filtros_remesas=json.dumps({"estatus": "A", "omitir_archivados": True, "juzgado_id": current_user.autoridad.id}),
         estatus="A",
         titulo="Archivo - Bandeja de Entrada 📥",
         estados_solicitudes=ArcSolicitud.ESTADOS,
         estados_remesas=ArcRemesa.ESTADOS,
-        tipos_documentos_remesas=ArcRemesa.TIPOS_DOCUMENTOS,
     )
 
 
@@ -119,14 +115,13 @@ def list_history():
     if current_user.can_admin(MODULO):
         return render_template(
             "arc_archivos/list_jefe_remesa.jinja2",
-            filtros_solicitudes=json.dumps({"estatus": "A", "mostrar_archivados": True, "orden_acendente": True}),
-            filtros_remesas=json.dumps({"estatus": "A", "mostrar_archivados": True, "orden_acendente": True}),
+            filtros_solicitudes=json.dumps({"estatus": "A", "mostrar_archivados": True, "omitir_cancelados": False, "orden_acendente": True}),
+            filtros_remesas=json.dumps({"estatus": "A", "mostrar_archivados": True, "omitir_cancelados": False, "orden_acendente": True}),
             estatus="A",
             titulo="Archivo - Historial 🗃️",
             mostrando_historial=True,
             estados_solicitudes=ArcSolicitud.ESTADOS,
             estados_remesas=ArcRemesa.ESTADOS,
-            tipos_documentos_remesas=ArcRemesa.TIPOS_DOCUMENTOS,
             mostrar_btn_local_global=mostrar_btn_local,
         )
     if ROL_SOLICITANTE in current_user_roles or ROL_RECEPCIONISTA in current_user_roles:
@@ -139,9 +134,8 @@ def list_history():
             mostrando_historial=True,
             estados_solicitudes=ArcSolicitud.ESTADOS,
             estados_remesas=ArcRemesa.ESTADOS,
-            tipos_documentos_remesas=ArcRemesa.TIPOS_DOCUMENTOS,
         )
-    if ROL_JEFE_REMESA in current_user_roles:
+    if ROL_JEFE_REMESA in current_user_roles or ROL_JEFE_REMESA_ADMINISTRADOR in current_user_roles:
         return render_template(
             "arc_archivos/list_jefe_remesa.jinja2",
             filtros_solicitudes=json.dumps({"estatus": "A", "mostrar_archivados": True, "omitir_cancelados": True, "orden_acendente": True, "distrito_id": current_user.autoridad.distrito_id}),
@@ -151,7 +145,6 @@ def list_history():
             mostrando_historial=True,
             estados_solicitudes=ArcSolicitud.ESTADOS,
             estados_remesas=ArcRemesa.ESTADOS,
-            tipos_documentos_remesas=ArcRemesa.TIPOS_DOCUMENTOS,
             rol_archivista=ROL_ARCHIVISTA,
             mostrar_btn_local_global=mostrar_btn_local,
         )
@@ -165,7 +158,6 @@ def list_history():
             mostrando_historial=True,
             estados_solicitudes=ArcSolicitud.ESTADOS,
             estados_remesas=ArcRemesa.ESTADOS,
-            tipos_documentos_remesas=ArcRemesa.TIPOS_DOCUMENTOS,
             rol_archivista=ROL_ARCHIVISTA,
         )
     # Por defecto
@@ -178,7 +170,6 @@ def list_history():
         mostrando_historial=True,
         estados_solicitudes=ArcSolicitud.ESTADOS,
         estados_remesas=ArcRemesa.ESTADOS,
-        tipos_documentos_remesas=ArcRemesa.TIPOS_DOCUMENTOS,
     )
 
 
@@ -206,20 +197,18 @@ def list_all(historial):
             mostrando_historial=True,
             estados_solicitudes=ArcSolicitud.ESTADOS,
             estados_remesas=ArcRemesa.ESTADOS,
-            tipos_documentos_remesas=ArcRemesa.TIPOS_DOCUMENTOS,
             mostrar_btn_local_global="GLOBAL",
             distritos=distritos,
         )
 
     return render_template(
         "arc_archivos/list_jefe_remesa.jinja2",
-        filtros_solicitudes=json.dumps({"estatus": "A", "omitir_archivados": True, "omitir_cancelados": True}),
-        filtros_remesas=json.dumps({"estatus": "A", "omitir_archivados": True, "omitir_cancelados": True, "omitir_pendientes": True}),
+        filtros_solicitudes=json.dumps({"estatus": "A", "omitir_archivados": True}),
+        filtros_remesas=json.dumps({"estatus": "A", "omitir_archivados": True, "omitir_pendientes": True}),
         estatus="A",
         titulo="Archivo - Bandeja de Entrada 📥",
         estados_solicitudes=ArcSolicitud.ESTADOS,
         estados_remesas=ArcRemesa.ESTADOS,
-        tipos_documentos_remesas=ArcRemesa.TIPOS_DOCUMENTOS,
         rol_archivista=ROL_ARCHIVISTA,
         mostrar_btn_local_global="GLOBAL",
         distritos=distritos,

--- a/plataforma_web/blueprints/arc_documentos_tipos/models.py
+++ b/plataforma_web/blueprints/arc_documentos_tipos/models.py
@@ -19,6 +19,7 @@ class ArcDocumentoTipo(db.Model, UniversalMixin):
 
     # Hijos
     arc_documentos_tipos = db.relationship("ArcDocumento", back_populates="arc_documento_tipo", lazy="noload")
+    arc_remesas = db.relationship("ArcRemesa", back_populates="arc_documento_tipo", lazy="noload")
 
     def __repr__(self):
         """Representación"""

--- a/plataforma_web/blueprints/arc_remesas/forms.py
+++ b/plataforma_web/blueprints/arc_remesas/forms.py
@@ -4,11 +4,9 @@ Archivo - Remesas, formularios
 from flask_wtf import FlaskForm
 from flask_login import current_user
 from datetime import date
-from wtforms.ext.sqlalchemy.fields import QuerySelectField
 from wtforms import IntegerField, StringField, SubmitField, TextAreaField, SelectField, BooleanField
 from wtforms.validators import DataRequired, Optional, Length, NumberRange
 
-from plataforma_web.blueprints.arc_remesas.models import ArcRemesa
 from plataforma_web.blueprints.arc_remesas_documentos.models import ArcRemesaDocumento
 
 
@@ -17,7 +15,7 @@ class ArcRemesaNewForm(FlaskForm):
 
     num_oficio = StringField("Núm. Oficio", validators=[Optional(), Length(max=16)])
     anio = IntegerField("Año", validators=[DataRequired(), NumberRange(1900, date.today().year)])
-    tipo_documentos = SelectField("Tipo de Documentos", choices=ArcRemesa.TIPOS_DOCUMENTOS, validators=[DataRequired()])
+    tipo_documentos = SelectField("Tipo de Documentos", coerce=int, validate_choice=False, validators=[DataRequired()])
     crear = SubmitField("Crear")
 
 

--- a/plataforma_web/blueprints/arc_remesas/models.py
+++ b/plataforma_web/blueprints/arc_remesas/models.py
@@ -23,6 +23,7 @@ class ArcRemesa(db.Model, UniversalMixin):
 
     TIPOS_DOCUMENTOS = OrderedDict(  # varchar(16)
         [
+            ("NO DEFINIDO", "No definido"),
             ("CUADERNILLO", "Cuadernillo"),
             ("ENCOMIENDA", "Encomienda"),
             ("EXHORTO", "Exhorto"),

--- a/plataforma_web/blueprints/arc_remesas/models.py
+++ b/plataforma_web/blueprints/arc_remesas/models.py
@@ -50,6 +50,8 @@ class ArcRemesa(db.Model, UniversalMixin):
     autoridad = db.relationship("Autoridad", back_populates="arc_remesas")
     usuario_asignado_id = db.Column(db.Integer, db.ForeignKey("usuarios.id"), index=True)
     usuario_asignado = db.relationship("Usuario", back_populates="arc_remesas")
+    arc_documento_tipo_id = db.Column(db.Integer, db.ForeignKey("arc_documentos_tipos.id"), index=True, nullable=False)
+    arc_documento_tipo = db.relationship("ArcDocumentoTipo", back_populates="arc_remesas")
 
     # Columnas
     anio = db.Column(db.Integer, nullable=False)
@@ -58,10 +60,12 @@ class ArcRemesa(db.Model, UniversalMixin):
     rechazo = db.Column(db.String(256))
     observaciones = db.Column(db.String(256))
     tiempo_enviado = db.Column(db.DateTime)
-    tipo_documentos = db.Column(
+    tipo_documentos = db.Column(  # FIXME: ELIMINAR (CAMPO OBSOLETO)
         db.Enum(*TIPOS_DOCUMENTOS, name="tipos", native_enum=False),
         index=True,
         nullable=False,
+        default="NO DEFINIDO",
+        server_default="NO DEFINIDO",
     )
     num_documentos = db.Column(db.Integer, nullable=False)
     num_anomalias = db.Column(db.Integer, nullable=False)

--- a/plataforma_web/blueprints/arc_remesas/models.py
+++ b/plataforma_web/blueprints/arc_remesas/models.py
@@ -21,19 +21,6 @@ class ArcRemesa(db.Model, UniversalMixin):
         ]
     )
 
-    TIPOS_DOCUMENTOS = OrderedDict(  # varchar(16)
-        [
-            ("NO DEFINIDO", "No definido"),
-            ("CUADERNILLO", "Cuadernillo"),
-            ("ENCOMIENDA", "Encomienda"),
-            ("EXHORTO", "Exhorto"),
-            ("EXPEDIENTE", "Expediente"),
-            ("EXPEDIENTILLO", "Expedientillo"),
-            ("FOLIO", "Folio"),
-            ("LIBRO", "Libro"),
-        ]
-    )
-
     RAZONES = OrderedDict(  # varchar(32)
         [
             ("SIN ORDEN CRONOLÓGICO", "Sin orden cronológico."),
@@ -61,13 +48,6 @@ class ArcRemesa(db.Model, UniversalMixin):
     rechazo = db.Column(db.String(256))
     observaciones = db.Column(db.String(256))
     tiempo_enviado = db.Column(db.DateTime)
-    tipo_documentos = db.Column(  # FIXME: ELIMINAR (CAMPO OBSOLETO)
-        db.Enum(*TIPOS_DOCUMENTOS, name="tipos", native_enum=False),
-        index=True,
-        nullable=False,
-        default="NO DEFINIDO",
-        server_default="NO DEFINIDO",
-    )
     num_documentos = db.Column(db.Integer, nullable=False)
     num_anomalias = db.Column(db.Integer, nullable=False)
     razon = db.Column(db.Enum(*RAZONES, name="razones", native_enum=False))

--- a/plataforma_web/blueprints/arc_remesas/templates/arc_remesas/add_document.jinja2
+++ b/plataforma_web/blueprints/arc_remesas/templates/arc_remesas/add_document.jinja2
@@ -20,7 +20,7 @@
         {{ detail.label_value('Demandado', documento.demandado) }}
         <hr>
         {{ detail.label_value('Juicio', documento.juicio) }}
-        {{ detail.label_value('Tipo de Documento', documento.tipo) }}
+        {{ detail.label_value('Tipo de Documento', documento.arc_documento_tipo.nombre) }}
         {{ detail.label_value('Tipo de Instancia', documento.tipo_juzgado) }}
         <hr>
         {{ detail.label_value('Fojas', documento.fojas) }}

--- a/plataforma_web/blueprints/arc_remesas/templates/arc_remesas/add_document.jinja2
+++ b/plataforma_web/blueprints/arc_remesas/templates/arc_remesas/add_document.jinja2
@@ -34,9 +34,9 @@
                 <select class="form-control" id="remesas" name="remesas" required>
                     {% for remesa in remesas %}
                         {% if remesa.num_oficio %}
-                            <option value="{{remesa.id}}">{{ remesa.id }}: {{ remesa.anio }} - {{ remesa.tipo_documentos }} : {{remesa.num_oficio}}</option>
+                            <option value="{{remesa.id}}">{{ remesa.id }}: {{ remesa.anio }} - {{ remesa.arc_documento_tipo.nombre }} : {{remesa.num_oficio}}</option>
                         {% else %}
-                            <option value="{{remesa.id}}">{{ remesa.id }}: {{ remesa.anio }} - {{ remesa.tipo_documentos }}</option>
+                            <option value="{{remesa.id}}">{{ remesa.id }}: {{ remesa.anio }} - {{ remesa.arc_documento_tipo.nombre }}</option>
                         {% endif %}
                     {% endfor %}
                 </select>

--- a/plataforma_web/blueprints/arc_remesas/templates/arc_remesas/detail.jinja2
+++ b/plataforma_web/blueprints/arc_remesas/templates/arc_remesas/detail.jinja2
@@ -65,7 +65,7 @@
         </div>
         {{ detail.label_value('Año', remesa.anio) }}
         {{ detail.label_value('Núm. Oficio', remesa.num_oficio) }}
-        {{ detail.label_value('Tipo de Documentos', remesa.tipo_documentos) }}
+        {{ detail.label_value('Tipo de Documentos', remesa.arc_documento_tipo.nombre) }}
         {% if remesa.num_anomalias > 0 %}
             <div class="row">
                 <div class="col-md-3 text-end">Núm. Anomalías</div>

--- a/plataforma_web/blueprints/arc_remesas/templates/arc_remesas/detail_archivista.jinja2
+++ b/plataforma_web/blueprints/arc_remesas/templates/arc_remesas/detail_archivista.jinja2
@@ -62,7 +62,7 @@
         </div>
         {{ detail.label_value('Año', remesa.anio) }}
         {{ detail.label_value('Núm. Oficio', remesa.num_oficio) }}
-        {{ detail.label_value('Tipo de Documentos', remesa.tipo_documentos) }}
+        {{ detail.label_value('Tipo de Documentos', remesa.arc_documento_tipo.nombre) }}
         {% if remesa.num_anomalias > 0 %}
             <div class="row">
                 <div class="col-md-3 text-end">Núm. Anomalías</div>

--- a/plataforma_web/blueprints/arc_remesas/templates/arc_remesas/detail_solicitante.jinja2
+++ b/plataforma_web/blueprints/arc_remesas/templates/arc_remesas/detail_solicitante.jinja2
@@ -68,7 +68,7 @@
         </div>
         {{ detail.label_value('Año', remesa.anio) }}
         {{ detail.label_value('Núm. Oficio', remesa.num_oficio) }}
-        {{ detail.label_value('Tipo de Documentos', remesa.tipo_documentos) }}
+        {{ detail.label_value('Tipo de Documentos', remesa.arc_documento_tipo.nombre) }}
         {% if remesa.num_anomalias > 0 %}
             <div class="row">
                 <div class="col-md-3 text-end">Núm. Anomalías</div>

--- a/plataforma_web/blueprints/arc_remesas/templates/arc_remesas/new.jinja2
+++ b/plataforma_web/blueprints/arc_remesas/templates/arc_remesas/new.jinja2
@@ -4,6 +4,13 @@
 
 {% block title %}Nueva Remesa{% endblock %}
 
+{% block custom_head %}
+    <!-- Select2 bootstrap -->
+    <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
+    <link href="https://storage.googleapis.com/pjecz-informatica/static/css/select2.css" rel="stylesheet" />
+{% endblock %}
+
+
 {% block topbar_actions %}
     {{ topbar.page('Nueva Remesa') }}
 {% endblock %}
@@ -17,4 +24,30 @@
             {% call f.form_group(form.crear) %}{% endcall %}
         {% endcall %}
     {% endcall %}
+{% endblock %}
+
+{% block custom_javascript %}
+    <!-- Select2 bootstrap -->
+    <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
+    <script>
+        $(document).ready(function(){
+            $('#tipo_documentos').addClass('js-example-placeholder-single');
+            $("#tipo_documentos").select2({
+                // --- Carga de emails por Ajax --- //
+                ajax: {
+                    url: '/arc_documentos_tipos/tipos_documentos_json',
+                    headers: { "X-CSRF-TOKEN": "{{ csrf_token() }}" },
+                    dataType: 'json',
+                    delay: 250,
+                    type: "POST",
+                    data: function (params) {
+                        return { 'nombre': params.term.toUpperCase() };
+                    }
+                },
+                placeholder: "",
+                minimumInputLength: 1,
+                allowClear: true
+            });
+        });
+    </script>
 {% endblock %}

--- a/plataforma_web/blueprints/arc_remesas/templates/arc_remesas/print_list.jinja2
+++ b/plataforma_web/blueprints/arc_remesas/templates/arc_remesas/print_list.jinja2
@@ -86,7 +86,7 @@
                     <td>{{ remesa.autoridad.clave }}</td>
                     <td>{{ remesa.anio }}</td>
                     <td>{{ remesa.num_oficio }}</td>
-                    <td>{{ remesa.tipo_documentos }}</td>
+                    <td>{{ remesa.arc_documento_tipo.nombre }}</td>
                     <td>{{ remesa.num_documentos }}</td>
                     <td>{{ remesa.estado }}</td>
                     <td>{{ remesa.observaciones }}</td>

--- a/plataforma_web/blueprints/arc_remesas/views.py
+++ b/plataforma_web/blueprints/arc_remesas/views.py
@@ -327,7 +327,7 @@ def new():
                 autoridad=current_user.autoridad,
                 esta_archivado=False,
                 anio=int(form.anio.data),
-                tipo_documentos=form.tipo_documentos.data,
+                arc_documento_tipo_id=form.tipo_documentos.data,
                 num_oficio=safe_string(form.num_oficio.data),
                 estado="PENDIENTE",
                 num_documentos=0,

--- a/plataforma_web/blueprints/arc_remesas/views.py
+++ b/plataforma_web/blueprints/arc_remesas/views.py
@@ -475,7 +475,7 @@ def edit(remesa_id):
     # Datos pre-cargados
     form.creado_readonly.data = remesa.creado.strftime("%Y/%m/%d - %H:%M %p")
     form.juzgado_readonly.data = remesa.autoridad.clave + " : " + remesa.autoridad.descripcion_corta
-    form.tipo_documentos_readonly.data = remesa.tipo_documentos
+    form.tipo_documentos_readonly.data = remesa.arc_documento_tipo.nombre
     form.anio.data = remesa.anio
     form.num_oficio.data = remesa.num_oficio
     form.observaciones.data = remesa.observaciones
@@ -579,8 +579,8 @@ def add_document(documento_id):
             flash("La remesa NO tiene un estado de PENDIENTE.", "warning")
         elif remesa.esta_archivado:
             flash("La remesa se encuentra ARCHIVADA, ya no puede ser modificada.", "warning")
-        elif remesa.tipo_documentos != documento.tipo:
-            flash(f"La remesa solo puede contener documentos del tipo {remesa.tipo_documentos}.", "warning")
+        elif remesa.arc_documento_tipo != documento.arc_documento_tipo:
+            flash(f"La remesa {remesa.id} solo puede contener documentos del tipo {remesa.arc_documento_tipo.nombre}.", "warning")
         elif remesa.estatus != "A":
             flash("La remesa está eliminada.", "warning")
         else:

--- a/plataforma_web/blueprints/arc_remesas/views.py
+++ b/plataforma_web/blueprints/arc_remesas/views.py
@@ -77,8 +77,8 @@ def datatable_json():
     if "anio" in request.form:
         anio = int(request.form["anio"])
         consulta = consulta.filter_by(anio=anio)
-    if "tipo_documento" in request.form:
-        consulta = consulta.filter_by(tipo_documentos=request.form["tipo_documento"])
+    if "arc_documento_tipo_id" in request.form:
+        consulta = consulta.filter_by(arc_documento_tipo_id=request.form["arc_documento_tipo_id"])
     if "num_oficio" in request.form:
         consulta = consulta.filter_by(num_oficio=request.form["num_oficio"])
     if "estado" in request.form:
@@ -125,7 +125,7 @@ def datatable_json():
                 "anio": resultado.anio,
                 "num_oficio": resultado.num_oficio,
                 "num_docs": resultado.num_documentos,
-                "tipo_documentos": resultado.tipo_documentos,
+                "tipo_documentos": resultado.arc_documento_tipo.nombre,
                 "estado": resultado.estado,
                 "asignado": {
                     "nombre": "SIN ASIGNAR" if resultado.usuario_asignado is None else resultado.usuario_asignado.nombre,

--- a/plataforma_web/blueprints/arc_remesas/views.py
+++ b/plataforma_web/blueprints/arc_remesas/views.py
@@ -36,6 +36,7 @@ from plataforma_web.blueprints.arc_remesas.forms import (
 
 from plataforma_web.blueprints.arc_archivos.views import (
     ROL_JEFE_REMESA,
+    ROL_JEFE_REMESA_ADMINISTRADOR,
     ROL_ARCHIVISTA,
     ROL_SOLICITANTE,
     ROL_RECEPCIONISTA,
@@ -155,7 +156,7 @@ def detail(remesa_id):
     rol_activo = None
     if ROL_SOLICITANTE in current_user_roles:
         rol_activo = ROL_SOLICITANTE
-    elif ROL_JEFE_REMESA in current_user_roles:
+    elif ROL_JEFE_REMESA in current_user_roles or ROL_JEFE_REMESA_ADMINISTRADOR in current_user_roles:
         rol_activo = ROL_JEFE_REMESA
     elif ROL_ARCHIVISTA in current_user_roles:
         rol_activo = ROL_ARCHIVISTA
@@ -233,7 +234,7 @@ def detail(remesa_id):
                 )
 
     if remesa.estado == "ENVIADO":
-        if ROL_JEFE_REMESA in current_user_roles:
+        if ROL_JEFE_REMESA in current_user_roles or ROL_JEFE_REMESA_ADMINISTRADOR in current_user_roles:
             mostrar_secciones["asignar"] = True
             mostrar_secciones["rechazar"] = True
             form = ArcRemesaAsignationForm()
@@ -254,7 +255,7 @@ def detail(remesa_id):
 
     if remesa.estado == "ASIGNADO":
         mostrar_secciones["asignado"] = True
-        if ROL_JEFE_REMESA in current_user_roles:
+        if ROL_JEFE_REMESA in current_user_roles or ROL_JEFE_REMESA_ADMINISTRADOR in current_user_roles:
             mostrar_secciones["asignar"] = True
             archivistas = Usuario.query.join(UsuarioRol).join(Rol)
             archivistas = archivistas.filter(Rol.nombre == ROL_ARCHIVISTA)
@@ -616,8 +617,8 @@ def asign(remesa_id):
     if form.validate_on_submit():
         if remesa.estado != "ENVIADO" and remesa.estado != "ASIGNADO":
             flash("No puede asignar a alguien estando la Remesa en un estado diferente a ENVIADO o ASIGNADO.", "warning")
-        elif not current_user.can_admin(MODULO) and ROL_JEFE_REMESA not in current_user.get_roles():
-            flash(f"Solo puede asignar el ROL de {ROL_JEFE_REMESA}.", "warning")
+        elif not current_user.can_admin(MODULO) and ROL_JEFE_REMESA not in current_user.get_roles() and ROL_JEFE_REMESA_ADMINISTRADOR not in current_user.get_roles():
+            flash(f"Solo puede asignar el ROL de {ROL_JEFE_REMESA} o {ROL_JEFE_REMESA_ADMINISTRADOR}.", "warning")
         else:
             if form.asignado.data is None or form.asignado.data == "":
                 remesa.estado = "ENVIADO"
@@ -659,8 +660,8 @@ def refuse(remesa_id):
     if form.validate_on_submit():
         if remesa.estado != "ENVIADO":
             flash("No puede rechazar la Remesa en un estado diferente a ENVIADO.", "warning")
-        elif not current_user.can_admin(MODULO) and ROL_JEFE_REMESA not in current_user.get_roles():
-            flash(f"Solo puede rechazar el ROL de {ROL_JEFE_REMESA}.", "warning")
+        elif not current_user.can_admin(MODULO) and ROL_JEFE_REMESA not in current_user.get_roles() and ROL_JEFE_REMESA_ADMINISTRADOR not in current_user.get_roles():
+            flash(f"Solo puede rechazar el ROL de {ROL_JEFE_REMESA} o {ROL_JEFE_REMESA_ADMINISTRADOR}.", "warning")
         else:
             # Cambiar de ubicación los documentos anexos
             documentos = ArcRemesaDocumento.query.filter_by(arc_remesa_id=remesa_id).all()

--- a/plataforma_web/blueprints/arc_remesas_documentos/templates/arc_remesas_documentos/print_list.jinja2
+++ b/plataforma_web/blueprints/arc_remesas_documentos/templates/arc_remesas_documentos/print_list.jinja2
@@ -66,7 +66,7 @@
     <body>
         <button onclick="window.print(); return false;">Imprimir</button>
         <h1>Listado de documentos anexos a la remesa {{ remesa.id }}</h1>
-        <h2>Instancia: <strong>{{ remesa.autoridad.clave }} - {{ remesa.autoridad.descripcion_corta }}</strong>, Tipo de Documentos: <strong>{{ remesa.tipo_documentos }}</strong>, Núm. de Oficio: <strong>{{ remesa.num_oficio }}</strong></h2>
+        <h2>Instancia: <strong>{{ remesa.autoridad.clave }} - {{ remesa.autoridad.descripcion_corta }}</strong>, Tipo de Documentos: <strong>{{ remesa.arc_documento_tipo.nombre }}</strong>, Núm. de Oficio: <strong>{{ remesa.num_oficio }}</strong></h2>
         <table id="arc_documentos_datatable" class="table display nowrap" style="width:100%">
             <thead>
                 <tr>


### PR DESCRIPTION
Ahora remesas utiliza el campo `arc_documento_tipo` para tomar los diferentes tipos de documentos de la tabla catalogo `arc_documentos_tipos`

También hice mejoras en la integración del nuevo ROL: **ARCHIVO JEFE REMESA ADMINISTRADOR**

Closed #681

Aclarar que hay que hacer modificaciones en la BD. Los apuntes están en el issue #681 