### PR TITLE
Ricval/archivo juzgados extintos

### DIFF
--- a/plataforma_web/blueprints/arc_documentos/templates/arc_documentos/list.jinja2
+++ b/plataforma_web/blueprints/arc_documentos/templates/arc_documentos/list.jinja2
@@ -17,6 +17,9 @@
             {# {% if estatus == 'A' %}{{ topbar.button_list_inactive('Inactivos', url_for('arc_documentos.list_inactive')) }}{% endif %} #}
             {% if estatus == 'B' %}{{ topbar.button_list_active('Activos', url_for('arc_documentos.list_active')) }}{% endif %}
         {% endif %}
+        {% if current_user.can_view('ARC JUZGADOS EXTINTOS') %}
+            {{ topbar.button('Juzgados Extintos', url_for('arc_juzgados_extintos.list_active'), 'mdi:map-marker-off') }}
+        {% endif %}
         {% if current_user.can_view('ARC DOCUMENTOS TIPOS') %}
             {{ topbar.button('Tipos de Documentos', url_for('arc_documentos_tipos.list_active'), 'mdi:file-code') }}
         {% endif %}

--- a/plataforma_web/blueprints/arc_documentos/templates/arc_documentos/list_admin.jinja2
+++ b/plataforma_web/blueprints/arc_documentos/templates/arc_documentos/list_admin.jinja2
@@ -15,6 +15,9 @@
         {% if current_user.can_edit('ARC DOCUMENTOS') %}
             {% if estatus == 'B' %}{{ topbar.button_list_active('Activos', url_for('arc_documentos.list_active')) }}{% endif %}
         {% endif %}
+        {% if current_user.can_view('ARC JUZGADOS EXTINTOS') %}
+            {{ topbar.button('Juzgados Extintos', url_for('arc_juzgados_extintos.list_active'), 'mdi:map-marker-off') }}
+        {% endif %}
         {% if current_user.can_view('ARC DOCUMENTOS TIPOS') %}
             {{ topbar.button('Tipos de Documentos', url_for('arc_documentos_tipos.list_active'), 'mdi:file-code') }}
         {% endif %}

--- a/plataforma_web/blueprints/arc_juzgados_extintos/forms.py
+++ b/plataforma_web/blueprints/arc_juzgados_extintos/forms.py
@@ -4,6 +4,14 @@ Archivo Juzgado Extinto, formularios
 from flask_wtf import FlaskForm
 from wtforms import StringField, SubmitField
 from wtforms.validators import DataRequired, Length
+from wtforms.ext.sqlalchemy.fields import QuerySelectField
+
+from plataforma_web.blueprints.distritos.models import Distrito
+
+
+def distritos_opciones():
+    """Opciones para select"""
+    return Distrito.query.filter_by(estatus="A").filter_by(es_distrito=True).order_by(Distrito.nombre_corto).all()
 
 
 class ArcJuzgadoExtintoForm(FlaskForm):
@@ -12,5 +20,5 @@ class ArcJuzgadoExtintoForm(FlaskForm):
     clave = StringField("Clave", validators=[DataRequired(), Length(max=16)])
     descripcion_corta = StringField("Descripción", validators=[DataRequired(), Length(max=64)])
     descripcion = StringField("Descripción", validators=[DataRequired(), Length(max=256)])
-    # distrito =
+    distrito = QuerySelectField("Distrito", query_factory=distritos_opciones, get_label="nombre_corto", validators=[DataRequired()])
     guardar = SubmitField("Guardar")

--- a/plataforma_web/blueprints/arc_juzgados_extintos/forms.py
+++ b/plataforma_web/blueprints/arc_juzgados_extintos/forms.py
@@ -1,0 +1,16 @@
+"""
+Archivo Juzgado Extinto, formularios
+"""
+from flask_wtf import FlaskForm
+from wtforms import StringField, SubmitField
+from wtforms.validators import DataRequired, Length
+
+
+class ArcJuzgadoExtintoForm(FlaskForm):
+    """Formulario ArcJuzgadoExtinto"""
+
+    clave = StringField("Clave", validators=[DataRequired(), Length(max=16)])
+    descripcion_corta = StringField("Descripción", validators=[DataRequired(), Length(max=64)])
+    descripcion = StringField("Descripción", validators=[DataRequired(), Length(max=256)])
+    # distrito =
+    guardar = SubmitField("Guardar")

--- a/plataforma_web/blueprints/arc_juzgados_extintos/models.py
+++ b/plataforma_web/blueprints/arc_juzgados_extintos/models.py
@@ -14,6 +14,10 @@ class ArcJuzgadoExtinto(db.Model, UniversalMixin):
     # Clave primaria
     id = db.Column(db.Integer, primary_key=True)
 
+    # Clave foránea
+    distrito_id = db.Column(db.Integer, db.ForeignKey("distritos.id"), index=True, nullable=False)
+    distrito = db.relationship("Distrito", back_populates="arc_juzgados_extintos")
+
     # Columnas
     clave = db.Column(db.String(16), nullable=False, unique=True)
     descripcion_corta = db.Column(db.String(64), nullable=False)

--- a/plataforma_web/blueprints/arc_juzgados_extintos/templates/arc_juzgados_extintos/detail.jinja2
+++ b/plataforma_web/blueprints/arc_juzgados_extintos/templates/arc_juzgados_extintos/detail.jinja2
@@ -1,0 +1,33 @@
+{% extends 'layouts/app.jinja2' %}
+{% import 'macros/detail.jinja2' as detail %}
+{% import 'macros/modals.jinja2' as modals %}
+{% import 'macros/topbar.jinja2' as topbar %}
+
+{% block title %}Juzgado Extinto{% endblock %}
+
+{% block topbar_actions %}
+    {% call topbar.page_buttons('Detalle Juzgado Extinto: ' + arc_juzgado_extinto.clave) %}
+        {{ topbar.button_previous('Juzgados Extintos', url_for('arc_juzgados_extintos.list_active')) }}
+        {% if current_user.can_edit('ARC JUZGADOS EXTINTOS') %}
+            {{ topbar.button_edit('Editar', url_for('arc_juzgados_extintos.edit', arc_juzgado_extinto_id=arc_juzgado_extinto.id)) }}
+            {% if arc_juzgado_extinto.estatus == 'A' %}{{ topbar.button_delete('Eliminar', url_for('arc_juzgados_extintos.delete', arc_juzgado_extinto_id=arc_juzgado_extinto.id)) }}{% endif %}
+            {% if arc_juzgado_extinto.estatus == 'B' %}{{ topbar.button_recover('Recuperar', url_for('arc_juzgados_extintos.recover', arc_juzgado_extinto_id=arc_juzgado_extinto.id)) }}{% endif %}
+        {% endif %}
+    {% endcall %}
+{% endblock %}
+
+{% block content %}
+    {% call detail.card(estatus=arc_juzgado_extinto.estatus) %}
+        {{ detail.label_value_big('Clave', arc_juzgado_extinto.clave) }}
+        {{ detail.label_value('Descripción Corta', arc_juzgado_extinto.descripcion_corta) }}
+        {{ detail.label_value('Descripción Completa', arc_juzgado_extinto.descripcion) }}
+    {% endcall %}
+{% endblock %}
+
+{% block custom_javascript %}
+    {% if current_user.can_edit('ARC JUZGADOS EXTINTOS') %}
+        {% if arc_juzgado_extinto.estatus == 'A' %}{{ modals.custom_javascript_delete('Eliminar', '¿Eliminar a ' + arc_juzgado_extinto.clave + '?') }}{% endif %}
+        {% if arc_juzgado_extinto.estatus == 'B' %}{{ modals.custom_javascript_recover('Recuperar', '¿Recuperar a ' + arc_juzgado_extinto.clave + '?') }}{% endif %}
+    {% endif %}
+    {{ detail.moment_js(moment) }}
+{% endblock %}

--- a/plataforma_web/blueprints/arc_juzgados_extintos/templates/arc_juzgados_extintos/detail.jinja2
+++ b/plataforma_web/blueprints/arc_juzgados_extintos/templates/arc_juzgados_extintos/detail.jinja2
@@ -19,6 +19,11 @@
 {% block content %}
     {% call detail.card(estatus=arc_juzgado_extinto.estatus) %}
         {{ detail.label_value_big('Clave', arc_juzgado_extinto.clave) }}
+        {% if current_user.can_view('DISTRITOS') %}
+            {{ detail.label_value('Distrito', arc_juzgado_extinto.distrito.nombre_corto, url_for('distritos.detail', distrito_id=arc_juzgado_extinto.distrito_id)) }}
+        {% else %}
+            {{ detail.label_value('Distrito', arc_juzgado_extinto.distrito.nombre_corto) }}
+        {% endif %}
         {{ detail.label_value('Descripción Corta', arc_juzgado_extinto.descripcion_corta) }}
         {{ detail.label_value('Descripción Completa', arc_juzgado_extinto.descripcion) }}
     {% endcall %}

--- a/plataforma_web/blueprints/arc_juzgados_extintos/templates/arc_juzgados_extintos/edit.jinja2
+++ b/plataforma_web/blueprints/arc_juzgados_extintos/templates/arc_juzgados_extintos/edit.jinja2
@@ -13,7 +13,7 @@
         {% set form_kwargs = {'arc_juzgado_extinto_id': arc_juzgado_extinto.id} %}
         {% call f.form_tag('arc_juzgados_extintos.edit', fid='arc_juzgado_extinto_form', **form_kwargs) %}
             {% call f.form_group(form.clave) %}{% endcall %}
-            {# {% call f.form_group(form.distrito) %}{% endcall %} #}
+            {% call f.form_group(form.distrito) %}{% endcall %}
             {% call f.form_group(form.descripcion_corta) %}{% endcall %}
             {% call f.form_group(form.descripcion) %}{% endcall %}
             {% call f.form_group(form.guardar) %}{% endcall %}

--- a/plataforma_web/blueprints/arc_juzgados_extintos/templates/arc_juzgados_extintos/edit.jinja2
+++ b/plataforma_web/blueprints/arc_juzgados_extintos/templates/arc_juzgados_extintos/edit.jinja2
@@ -1,0 +1,22 @@
+{% extends 'layouts/app.jinja2' %}
+{% import 'macros/form.jinja2' as f with context %}
+{% import 'macros/topbar.jinja2' as topbar %}
+
+{% block title %}Editar Juzgado Extinto{% endblock %}
+
+{% block topbar_actions %}
+    {{ topbar.page('Editar ' + arc_juzgado_extinto.clave) }}
+{% endblock %}
+
+{% block content %}
+    {% call f.card() %}
+        {% set form_kwargs = {'arc_juzgado_extinto_id': arc_juzgado_extinto.id} %}
+        {% call f.form_tag('arc_juzgados_extintos.edit', fid='arc_juzgado_extinto_form', **form_kwargs) %}
+            {% call f.form_group(form.clave) %}{% endcall %}
+            {# {% call f.form_group(form.distrito) %}{% endcall %} #}
+            {% call f.form_group(form.descripcion_corta) %}{% endcall %}
+            {% call f.form_group(form.descripcion) %}{% endcall %}
+            {% call f.form_group(form.guardar) %}{% endcall %}
+        {% endcall %}
+    {% endcall %}
+{% endblock %}

--- a/plataforma_web/blueprints/arc_juzgados_extintos/templates/arc_juzgados_extintos/list.jinja2
+++ b/plataforma_web/blueprints/arc_juzgados_extintos/templates/arc_juzgados_extintos/list.jinja2
@@ -1,0 +1,74 @@
+{% extends 'layouts/app.jinja2' %}
+{% import 'macros/list.jinja2' as list %}
+{% import 'macros/topbar.jinja2' as topbar %}
+
+{% block title %}Juzgados Extintos{% endblock %}
+
+{% block topbar_actions %}
+    {% call topbar.page_buttons(titulo) %}
+        {% if current_user.can_edit('ARC JUZGADOS EXTINTOS') %}
+            {% if estatus == 'A' %}{{ topbar.button_list_inactive('Inactivos', url_for('arc_juzgados_extintos.list_inactive')) }}{% endif %}
+            {% if estatus == 'B' %}{{ topbar.button_list_active('Activos', url_for('arc_juzgados_extintos.list_active')) }}{% endif %}
+        {% endif %}
+        {{ topbar.button_previous('Expedientes', url_for('arc_documentos.list_active')) }}
+        {% if current_user.can_insert('ARC JUZGADOS EXTINTOS') %}
+            {{ topbar.button_new('Nuevo Juzgado Extinto', url_for('arc_juzgados_extintos.new')) }}
+        {% endif %}
+    {% endcall %}
+{% endblock %}
+
+{% block content %}
+    {% call list.card() %}
+        <table id="arc_juzgados_extintos_datatable" class="table {% if estatus == 'B'%}table-dark{% endif %} display nowrap" style="width:100%">
+            <thead>
+                <tr>
+                    <th>Clave</th>
+                    <th>Descripción Corta</th>
+                    <th>Distrito</th>
+                    <th>Descripción Completa</th>
+                </tr>
+            </thead>
+        </table>
+    {% endcall %}
+{% endblock %}
+
+{% block custom_javascript %}
+    <!-- Importación de la configuración para DataTables -->
+    <script src="/static/js/datatables_config.js"></script>
+    <script>
+        const dataTable_funcs = new ConfigDataTable( "{{ csrf_token() }}" );
+        let configDataTable = dataTable_funcs.config;
+        configDataTable['ajax']['url'] = '/arc_juzgados_extintos/datatable_json';
+        configDataTable['ajax']['data'] = {{ filtros }};
+        configDataTable['columns'] = [
+            { data: 'detalle' },
+            { data: 'descripcion_corta' },
+            { data: 'distrito' },
+            { data: 'descripcion' }
+        ];
+        configDataTable['columnDefs'] = [
+            {
+                targets: 0, // detalle
+                data: null,
+                render: function(data, type, row, meta) {
+                    return dataTable_funcs.texto_con_url(data.clave, data.url);
+                }
+            },
+            {
+                targets: 2, // distrito
+                data: null,
+                render: function(data, type, row, meta) {
+                    return dataTable_funcs.texto_con_url(data.nombre, data.url);
+                }
+            },
+            {
+                targets: 3, // descripcion
+                data: null,
+                render: function(data, type, row, meta) {
+                    return dataTable_funcs.texto_cortado(data);
+                }
+            },
+        ];
+        $('#arc_juzgados_extintos_datatable').DataTable(configDataTable);
+    </script>
+{% endblock %}

--- a/plataforma_web/blueprints/arc_juzgados_extintos/templates/arc_juzgados_extintos/new.jinja2
+++ b/plataforma_web/blueprints/arc_juzgados_extintos/templates/arc_juzgados_extintos/new.jinja2
@@ -1,0 +1,21 @@
+{% extends 'layouts/app.jinja2' %}
+{% import 'macros/form.jinja2' as f with context %}
+{% import 'macros/topbar.jinja2' as topbar %}
+
+{% block title %}Nuevo Juzgado Extinto{% endblock %}
+
+{% block topbar_actions %}
+    {{ topbar.page('Nuevo Juzgado Extinto') }}
+{% endblock %}
+
+{% block content %}
+    {% call f.card() %}
+        {% call f.form_tag('arc_juzgados_extintos.new', fid='arc_juzgado_extinto_form') %}
+            {% call f.form_group(form.clave) %}{% endcall %}
+            {# {% call f.form_group(form.distrito) %}{% endcall %} #}
+            {% call f.form_group(form.descripcion_corta) %}{% endcall %}
+            {% call f.form_group(form.descripcion) %}{% endcall %}
+            {% call f.form_group(form.guardar) %}{% endcall %}
+        {% endcall %}
+    {% endcall %}
+{% endblock %}

--- a/plataforma_web/blueprints/arc_juzgados_extintos/templates/arc_juzgados_extintos/new.jinja2
+++ b/plataforma_web/blueprints/arc_juzgados_extintos/templates/arc_juzgados_extintos/new.jinja2
@@ -12,7 +12,7 @@
     {% call f.card() %}
         {% call f.form_tag('arc_juzgados_extintos.new', fid='arc_juzgado_extinto_form') %}
             {% call f.form_group(form.clave) %}{% endcall %}
-            {# {% call f.form_group(form.distrito) %}{% endcall %} #}
+            {% call f.form_group(form.distrito) %}{% endcall %}
             {% call f.form_group(form.descripcion_corta) %}{% endcall %}
             {% call f.form_group(form.descripcion) %}{% endcall %}
             {% call f.form_group(form.guardar) %}{% endcall %}

--- a/plataforma_web/blueprints/arc_juzgados_extintos/views.py
+++ b/plataforma_web/blueprints/arc_juzgados_extintos/views.py
@@ -1,13 +1,20 @@
 """
 Archivo Juzgados Extintos, vistas
 """
-from flask import Blueprint
-from flask_login import login_required
+import json
+from flask import Blueprint, flash, redirect, render_template, request, url_for
+from flask_login import current_user, login_required
+
+from lib.datatables import get_datatable_parameters, output_datatable_json
+from lib.safe_string import safe_message, safe_string, safe_clave
+
+from plataforma_web.blueprints.bitacoras.models import Bitacora
+from plataforma_web.blueprints.modulos.models import Modulo
+from plataforma_web.blueprints.permisos.models import Permiso
 from plataforma_web.blueprints.usuarios.decorators import permission_required
 
 from plataforma_web.blueprints.arc_juzgados_extintos.models import ArcJuzgadoExtinto
-from plataforma_web.blueprints.permisos.models import Permiso
-
+from plataforma_web.blueprints.arc_juzgados_extintos.forms import ArcJuzgadoExtintoForm
 
 MODULO = "ARC JUZGADOS EXTINTOS"
 
@@ -19,3 +26,164 @@ arc_juzgados_extintos = Blueprint("arc_juzgados_extintos", __name__, template_fo
 @permission_required(MODULO, Permiso.VER)
 def before_request():
     """Permiso por defecto"""
+
+
+@arc_juzgados_extintos.route("/arc_juzgados_extintos/datatable_json", methods=["GET", "POST"])
+def datatable_json():
+    """DataTable JSON para listado de Juzgados Extintos"""
+    # Tomar parámetros de Datatables
+    draw, start, rows_per_page = get_datatable_parameters()
+    # Consultar
+    consulta = ArcJuzgadoExtinto.query
+    if "estatus" in request.form:
+        consulta = consulta.filter_by(estatus=request.form["estatus"])
+    else:
+        consulta = consulta.filter_by(estatus="A")
+    registros = consulta.order_by(ArcJuzgadoExtinto.clave).offset(start).limit(rows_per_page).all()
+    total = consulta.count()
+    # Elaborar datos para DataTable
+    data = []
+    for resultado in registros:
+        data.append(
+            {
+                "detalle": {
+                    "clave": resultado.clave,
+                    "url": url_for("arc_juzgados_extintos.detail", arc_juzgado_extinto_id=resultado.id),
+                },
+                "descripcion_corta": resultado.descripcion_corta,
+                "descripcion": resultado.descripcion,
+                "distrito": {
+                    "nombre": "X",
+                    "url": url_for("distritos.detail", distrito_id=1) if current_user.can_view("DISTRITOS") else "",
+                },
+            }
+        )
+    # Entregar JSON
+    return output_datatable_json(draw, total, data)
+
+
+@arc_juzgados_extintos.route("/arc_juzgados_extintos")
+def list_active():
+    """Listado de Juzgados Extintos activos"""
+    return render_template(
+        "arc_juzgados_extintos/list.jinja2",
+        filtros=json.dumps({"estatus": "A"}),
+        titulo="Juzgados Extintos",
+        estatus="A",
+    )
+
+
+@arc_juzgados_extintos.route("/arc_juzgados_extintos/inactivos")
+@permission_required(MODULO, Permiso.MODIFICAR)
+def list_inactive():
+    """Listado de Juzgados Extintos inactivos"""
+    return render_template(
+        "arc_juzgados_extintos/list.jinja2",
+        filtros=json.dumps({"estatus": "B"}),
+        titulo="Juzgados Extintos inactivos",
+        estatus="B",
+    )
+
+
+@arc_juzgados_extintos.route("/arc_juzgados_extintos/<int:arc_juzgado_extinto_id>")
+def detail(arc_juzgado_extinto_id):
+    """Detalle de un Juzgado Extinto"""
+    arc_juzgado_extinto = ArcJuzgadoExtinto.query.get_or_404(arc_juzgado_extinto_id)
+    return render_template("arc_juzgados_extintos/detail.jinja2", arc_juzgado_extinto=arc_juzgado_extinto)
+
+
+@arc_juzgados_extintos.route("/arc_juzgados_extintos/nuevo", methods=["GET", "POST"])
+@permission_required(MODULO, Permiso.CREAR)
+def new():
+    """Nuevo Juzgado Extinto"""
+    form = ArcJuzgadoExtintoForm()
+    if form.validate_on_submit():
+        # Validar que la clave sea única
+        clave = safe_clave(form.clave.data)
+        if ArcJuzgadoExtinto.query.filter_by(clave=clave).first():
+            flash(f"La clave '{clave}' ya se encuentra en uso. Utilice una diferente.", "warning")
+        else:
+            arc_juzgado_extinto = ArcJuzgadoExtinto(
+                clave=clave,
+                descripcion_corta=safe_string(form.descripcion_corta.data),
+                descripcion=safe_string(form.descripcion.data),
+            )
+            arc_juzgado_extinto.save()
+            bitacora = Bitacora(
+                modulo=Modulo.query.filter_by(nombre=MODULO).first(),
+                usuario=current_user,
+                descripcion=safe_message(f"Nuevo Juzgado Extinto {arc_juzgado_extinto.clave}"),
+                url=url_for("arc_juzgados_extintos.detail", arc_juzgado_extinto_id=arc_juzgado_extinto.id),
+            )
+            bitacora.save()
+            flash(bitacora.descripcion, "success")
+            return redirect(bitacora.url)
+    return render_template("arc_juzgados_extintos/new.jinja2", form=form)
+
+
+@arc_juzgados_extintos.route("/arc_juzgados_extintos/edicion/<int:arc_juzgado_extinto_id>", methods=["GET", "POST"])
+@permission_required(MODULO, Permiso.MODIFICAR)
+def edit(arc_juzgado_extinto_id):
+    """Editar Juzgado Extinto"""
+    arc_juzgado_extinto = ArcJuzgadoExtinto.query.get_or_404(arc_juzgado_extinto_id)
+    form = ArcJuzgadoExtintoForm()
+    if form.validate_on_submit():
+        # Validar que la clave sea única
+        clave = safe_clave(form.clave.data)
+        if ArcJuzgadoExtinto.query.filter_by(clave=clave).filter(ArcJuzgadoExtinto.id != arc_juzgado_extinto_id).first():
+            flash(f"La clave '{clave}' ya se encuentra en uso. Utilice una diferente.", "warning")
+        else:
+            arc_juzgado_extinto.clave = clave
+            arc_juzgado_extinto.descripcion_corta = safe_string(form.descripcion_corta.data)
+            arc_juzgado_extinto.descripcion = safe_string(form.descripcion.data)
+            arc_juzgado_extinto.save()
+            bitacora = Bitacora(
+                modulo=Modulo.query.filter_by(nombre=MODULO).first(),
+                usuario=current_user,
+                descripcion=safe_message(f"Editado Juzgado Extinto {arc_juzgado_extinto.clave}"),
+                url=url_for("arc_juzgados_extintos.detail", arc_juzgado_extinto_id=arc_juzgado_extinto.id),
+            )
+            bitacora.save()
+            flash(bitacora.descripcion, "success")
+            return redirect(bitacora.url)
+    # Cargar valores guardados
+    form.clave.data = arc_juzgado_extinto.clave
+    form.descripcion_corta.data = arc_juzgado_extinto.descripcion_corta
+    form.descripcion.data = arc_juzgado_extinto.descripcion
+    return render_template("arc_juzgados_extintos/edit.jinja2", form=form, arc_juzgado_extinto=arc_juzgado_extinto)
+
+
+@arc_juzgados_extintos.route("/arc_juzgados_extintos/eliminar/<int:arc_juzgado_extinto_id>")
+@permission_required(MODULO, Permiso.MODIFICAR)
+def delete(arc_juzgado_extinto_id):
+    """Eliminar Juzgado Extinto"""
+    arc_juzgado_extinto = ArcJuzgadoExtinto.query.get_or_404(arc_juzgado_extinto_id)
+    if arc_juzgado_extinto.estatus == "A":
+        arc_juzgado_extinto.delete()
+        bitacora = Bitacora(
+            modulo=Modulo.query.filter_by(nombre=MODULO).first(),
+            usuario=current_user,
+            descripcion=safe_message(f"Eliminado Juzgado Extinto {arc_juzgado_extinto.clave}"),
+            url=url_for("arc_juzgados_extintos.detail", arc_juzgado_extinto_id=arc_juzgado_extinto.id),
+        )
+        bitacora.save()
+        flash(bitacora.descripcion, "success")
+    return redirect(url_for("arc_juzgados_extintos.detail", arc_juzgado_extinto_id=arc_juzgado_extinto.id))
+
+
+@arc_juzgados_extintos.route("/arc_juzgados_extintos/recuperar/<int:arc_juzgado_extinto_id>")
+@permission_required(MODULO, Permiso.MODIFICAR)
+def recover(arc_juzgado_extinto_id):
+    """Recuperar Juzgado Extinto"""
+    arc_juzgado_extinto = ArcJuzgadoExtinto.query.get_or_404(arc_juzgado_extinto_id)
+    if arc_juzgado_extinto.estatus == "B":
+        arc_juzgado_extinto.recover()
+        bitacora = Bitacora(
+            modulo=Modulo.query.filter_by(nombre=MODULO).first(),
+            usuario=current_user,
+            descripcion=safe_message(f"Recuperado Juzgado Extinto {arc_juzgado_extinto.clave}"),
+            url=url_for("arc_juzgados_extintos.detail", arc_juzgado_extinto_id=arc_juzgado_extinto.id),
+        )
+        bitacora.save()
+        flash(bitacora.descripcion, "success")
+    return redirect(url_for("arc_juzgados_extintos.detail", arc_juzgado_extinto_id=arc_juzgado_extinto.id))

--- a/plataforma_web/blueprints/arc_juzgados_extintos/views.py
+++ b/plataforma_web/blueprints/arc_juzgados_extintos/views.py
@@ -53,8 +53,8 @@ def datatable_json():
                 "descripcion_corta": resultado.descripcion_corta,
                 "descripcion": resultado.descripcion,
                 "distrito": {
-                    "nombre": "X",
-                    "url": url_for("distritos.detail", distrito_id=1) if current_user.can_view("DISTRITOS") else "",
+                    "nombre": resultado.distrito.nombre_corto,
+                    "url": url_for("distritos.detail", distrito_id=resultado.distrito_id) if current_user.can_view("DISTRITOS") else "",
                 },
             }
         )
@@ -105,6 +105,7 @@ def new():
         else:
             arc_juzgado_extinto = ArcJuzgadoExtinto(
                 clave=clave,
+                distrito=form.distrito.data,
                 descripcion_corta=safe_string(form.descripcion_corta.data),
                 descripcion=safe_string(form.descripcion.data),
             )
@@ -134,6 +135,7 @@ def edit(arc_juzgado_extinto_id):
             flash(f"La clave '{clave}' ya se encuentra en uso. Utilice una diferente.", "warning")
         else:
             arc_juzgado_extinto.clave = clave
+            arc_juzgado_extinto.distrito = form.distrito.data
             arc_juzgado_extinto.descripcion_corta = safe_string(form.descripcion_corta.data)
             arc_juzgado_extinto.descripcion = safe_string(form.descripcion.data)
             arc_juzgado_extinto.save()
@@ -148,6 +150,7 @@ def edit(arc_juzgado_extinto_id):
             return redirect(bitacora.url)
     # Cargar valores guardados
     form.clave.data = arc_juzgado_extinto.clave
+    form.distrito.data = arc_juzgado_extinto.distrito
     form.descripcion_corta.data = arc_juzgado_extinto.descripcion_corta
     form.descripcion.data = arc_juzgado_extinto.descripcion
     return render_template("arc_juzgados_extintos/edit.jinja2", form=form, arc_juzgado_extinto=arc_juzgado_extinto)

--- a/plataforma_web/blueprints/distritos/models.py
+++ b/plataforma_web/blueprints/distritos/models.py
@@ -23,6 +23,7 @@ class Distrito(db.Model, UniversalMixin):
     es_jurisdiccional = db.Column(db.Boolean, nullable=False, default=False)
 
     # Hijos
+    arc_juzgados_extintos = db.relationship("ArcJuzgadoExtinto", back_populates="distrito")
     autoridades = db.relationship("Autoridad", back_populates="distrito")
     centros_trabajos = db.relationship("CentroTrabajo", back_populates="distrito", lazy="noload")
     domicilios = db.relationship("Domicilio", back_populates="distrito", lazy="noload")


### PR DESCRIPTION
Se crearon las vistas para administrar los juzgados extintos.
Además se añadió una columna para enlazarlos a un Distrito. (Pensando a futuro).

Hacer cambios en Base de Datos indicados en el issue #689

Closed #689 