### PR TITLE
Añadido campo expediente_numero y validaciones nuevas

### DIFF
--- a/plataforma_web/blueprints/arc_documentos/forms.py
+++ b/plataforma_web/blueprints/arc_documentos/forms.py
@@ -21,7 +21,7 @@ def juzgados_extintos_opciones():
 class ArcDocumentoNewArchivoForm(FlaskForm):
     """Formulario nuevo Documento"""
 
-    num_expediente = StringField("Núm. Expediente", validators=[DataRequired(), Length(max=16), Regexp(EXPEDIENTE_REGEXP)])
+    expediente = StringField("Núm. Expediente (999/año)", validators=[DataRequired(), Length(max=16), Regexp(EXPEDIENTE_REGEXP)])
     anio = IntegerField("Año", validators=[DataRequired(), NumberRange(1900, date.today().year)])
     juzgado_id = SelectField("Instancia", coerce=int, validate_choice=False, validators=[DataRequired()])
     actor = StringField("Actor(es)", validators=[DataRequired(), Length(max=256)])
@@ -40,7 +40,7 @@ class ArcDocumentoNewArchivoForm(FlaskForm):
 class ArcDocumentoNewSolicitanteForm(FlaskForm):
     """Formulario nuevo Documento"""
 
-    num_expediente = StringField("Núm. Expediente", validators=[DataRequired(), Length(max=16), Regexp(EXPEDIENTE_REGEXP)])
+    expediente = StringField("Núm. Expediente (999/año)", validators=[DataRequired(), Length(max=16), Regexp(EXPEDIENTE_REGEXP)])
     anio = IntegerField("Año", validators=[DataRequired(), NumberRange(1900, date.today().year)])
     juzgado_readonly = StringField("Instancia")
     actor = StringField("Actor(es)", validators=[DataRequired(), Length(max=256)])
@@ -59,7 +59,7 @@ class ArcDocumentoNewSolicitanteForm(FlaskForm):
 class ArcDocumentoEditArchivoForm(FlaskForm):
     """Formulario modificar Documento"""
 
-    num_expediente = StringField("Núm. Expediente", validators=[DataRequired(), Length(max=16), Regexp(EXPEDIENTE_REGEXP)])
+    expediente = StringField("Núm. Expediente (999/año)", validators=[DataRequired(), Length(max=16), Regexp(EXPEDIENTE_REGEXP)])
     anio = IntegerField("Año", validators=[DataRequired(), NumberRange(1900, date.today().year)])
     juzgado_id = SelectField("Instancia", coerce=int, validate_choice=False, validators=[DataRequired()])
     actor = StringField("Actor(es)", validators=[DataRequired(), Length(max=256)])
@@ -79,7 +79,7 @@ class ArcDocumentoEditArchivoForm(FlaskForm):
 class ArcDocumentoEditSolicitanteForm(FlaskForm):
     """Formulario modificar Documento"""
 
-    num_expediente = StringField("Núm. Expediente", validators=[DataRequired(), Length(max=16), Regexp(EXPEDIENTE_REGEXP)])
+    expediente = StringField("Núm. Expediente (999/año)", validators=[DataRequired(), Length(max=16), Regexp(EXPEDIENTE_REGEXP)])
     anio = IntegerField("Año", validators=[DataRequired(), NumberRange(1900, date.today().year)])
     juzgado_readonly = StringField("Instancia")
     actor = StringField("Actor(es)", validators=[DataRequired(), Length(max=256)])

--- a/plataforma_web/blueprints/arc_documentos/models.py
+++ b/plataforma_web/blueprints/arc_documentos/models.py
@@ -44,6 +44,7 @@ class ArcDocumento(db.Model, UniversalMixin):
     anio = db.Column(db.Integer, nullable=False)
     demandado = db.Column(db.String(256))
     expediente = db.Column(db.String(16), index=True, nullable=False)  # dígitos/YYYY-XXX
+    expediente_numero = db.Column(db.Integer)  # TODO: nullable=False
     juicio = db.Column(db.String(128))
     fojas = db.Column(db.Integer, nullable=False)
     tipo_juzgado = db.Column(

--- a/plataforma_web/blueprints/arc_documentos/templates/arc_documentos/edit.jinja2
+++ b/plataforma_web/blueprints/arc_documentos/templates/arc_documentos/edit.jinja2
@@ -41,7 +41,7 @@
     {% call f.card() %}
         {% set form_kwargs = {'arc_documento_id': documento.id} %}
         {% call f.form_tag('arc_documentos.edit', fid='documento_form', **form_kwargs) %}
-            {% call f.form_group(form.num_expediente) %}{% endcall %}
+            {% call f.form_group(form.expediente) %}{% endcall %}
             {% call f.form_group(form.anio) %}{% endcall %}
             {% if form.juzgado_readonly %}
                 {% call f.form_group(form.juzgado_readonly, readonly=true) %}{% endcall %}

--- a/plataforma_web/blueprints/arc_documentos/templates/arc_documentos/new.jinja2
+++ b/plataforma_web/blueprints/arc_documentos/templates/arc_documentos/new.jinja2
@@ -44,7 +44,7 @@
     {# Formulario para alta de documento #}
     {% call f.card() %}
         {% call f.form_tag('arc_documentos.new', fid='documento_form') %}
-            {% call f.form_group(form.num_expediente) %}{% endcall %}
+            {% call f.form_group(form.expediente) %}{% endcall %}
             {% call f.form_group(form.anio) %}{% endcall %}
             {% if form.juzgado_readonly %}
                 {% call f.form_group(form.juzgado_readonly, readonly=true) %}{% endcall %}


### PR DESCRIPTION
Ya se pueden agregar **números de expediente** repetidos pero respetando que sean únicos en: **Juzgado** y **Tipo**.

Además añadí un nuevo campo para almacenar el número de expediente como valor numérico. Solo faltaría hacer la actualización en BD de los registros viejos, para comenzar a ordenarlo por éste campo.