### PR TITLE
Ricval/archivo actualizar expdientes

### DIFF
--- a/cli/commands/cmd_archivos.py
+++ b/cli/commands/cmd_archivos.py
@@ -1,0 +1,52 @@
+"""
+Archivos
+
+- actualizar_expedientes_anios_nums: Descompone el num-expedientes en número y año, y lo guarda individualmente como números.
+"""
+import click
+
+from lib.safe_string import extract_expediente_anio, extract_expediente_num
+
+from plataforma_web.app import create_app
+from plataforma_web.extensions import db
+
+from plataforma_web.blueprints.arc_documentos.models import ArcDocumento
+
+app = create_app()
+db.app = app
+
+
+@click.group()
+def cli():
+    """Archivos"""
+
+
+@click.command()
+def actualizar_expedientes_anios_nums():
+    """Actualizar el anio y el numero de los expedientes"""
+    click.echo("Actualizar el anio y el numero de los expedientes")
+    database = db.session
+    contador = 0
+    documentos = ArcDocumento.query.filter_by(estatus="A")
+    for documento in documentos:
+        if documento.anio is None or documento.expediente_numero is None:
+            anio = extract_expediente_anio(documento.expediente)
+            if anio != 0:
+                documento.anio = anio
+            num = extract_expediente_num(documento.expediente)
+            if num != 0:
+                documento.expediente_numero = num
+            if anio != 0 and num != 0:
+                database.add(documento)
+            else:
+                click.echo(f"!  Error en expediente ID[{documento.id}]: '{documento.expediente}'")
+            contador += 1
+            if contador % 100 == 0:
+                database.commit()
+                click.echo(f"  Van {contador}...")
+    if contador > 0 and contador % 100 != 0:
+        database.commit()
+    click.echo(f"Actualizados {contador} documentos")
+
+
+cli.add_command(actualizar_expedientes_anios_nums)

--- a/plataforma_web/blueprints/arc_documentos/views.py
+++ b/plataforma_web/blueprints/arc_documentos/views.py
@@ -80,8 +80,7 @@ def datatable_json():
         consulta = consulta.join(Autoridad)
         consulta = consulta.filter(Autoridad.distrito_id == distrito_id)
     # Ordena los registros resultantes por id descendientes para ver los más recientemente capturados
-    # TODO: Ordenar en lugar de .expediente por .expediente_numero
-    registros = consulta.order_by(ArcDocumento.anio).order_by(ArcDocumento.expediente).offset(start).limit(rows_per_page).all()
+    registros = consulta.order_by(ArcDocumento.anio).order_by(ArcDocumento.expediente_numero).offset(start).limit(rows_per_page).all()
     total = consulta.count()
     # Elaborar datos para DataTable
     data = []

--- a/plataforma_web/blueprints/arc_remesas_documentos/views.py
+++ b/plataforma_web/blueprints/arc_remesas_documentos/views.py
@@ -57,7 +57,7 @@ def datatable_json():
         consulta = consulta.filter(ArcRemesaDocumento.arc_remesa_id == request.form["remesa_id"])
 
     # Ordena los registros resultantes por fecha y número de expediente
-    registros = consulta.order_by(ArcDocumento.anio.desc()).order_by(ArcDocumento.expediente.desc()).offset(start).limit(rows_per_page).all()
+    registros = consulta.order_by(ArcDocumento.anio.desc()).order_by(ArcDocumento.expediente_numero.desc()).offset(start).limit(rows_per_page).all()
     total = consulta.count()
     # Elaborar datos para DataTable
     data = []
@@ -363,7 +363,7 @@ def print_list(remesa_id):
     # Extremos el listado de documentos anexos de la remesa
     documentos_anexos = ArcRemesaDocumento.query.filter_by(arc_remesa_id=remesa_id).filter_by(estatus="A")
     documentos_anexos = documentos_anexos.join(ArcDocumento)
-    documentos_anexos = documentos_anexos.order_by(ArcDocumento.anio.desc()).order_by(ArcDocumento.expediente.desc()).all()
+    documentos_anexos = documentos_anexos.order_by(ArcDocumento.anio.desc()).order_by(ArcDocumento.expediente_numero.desc()).all()
 
     # Resultado final de éxito
     return render_template("arc_remesas_documentos/print_list.jinja2", remesa=remesa, documentos_anexos=documentos_anexos)


### PR DESCRIPTION
Listo el CLI para actualizar el número de expediente de forma dividida en número y año en campos numéricos.

Ejecutar comando:
```BASH
plataforma_web archivos actualizar-expedientes-anios-nums
```

También se incluye el nuevo orden de los listados por estos campos divididos. Año y después número de expediente.

Closed: #697 