### PR TITLE
Archivo - NO editar ubicacion expediente

### DIFF
--- a/plataforma_web/blueprints/arc_documentos/forms.py
+++ b/plataforma_web/blueprints/arc_documentos/forms.py
@@ -56,6 +56,25 @@ class ArcDocumentoNewSolicitanteForm(FlaskForm):
     crear = SubmitField("Crear")
 
 
+class ArcDocumentoNewNoUbicacionForm(FlaskForm):
+    """Formulario nuevo Documento"""
+
+    expediente = StringField("Núm. Expediente (999/año)", validators=[DataRequired(), Length(max=16), Regexp(EXPEDIENTE_REGEXP)])
+    anio = IntegerField("Año", validators=[DataRequired(), NumberRange(1900, date.today().year)])
+    juzgado_id = SelectField("Instancia", coerce=int, validate_choice=False, validators=[DataRequired()])
+    actor = StringField("Actor(es)", validators=[DataRequired(), Length(max=256)])
+    demandado = StringField("Demandado(s)", validators=[Optional(), Length(max=256)])
+    juicio = StringField("Juicio", validators=[Optional(), Length(max=128)])
+    juzgado_origen = QuerySelectField("Instancia de Origen", query_factory=juzgados_extintos_opciones, get_label="nombre", validators=[Optional()], allow_blank=True)
+    tipo = SelectField("Tipo de Documento", coerce=int, validate_choice=False, validators=[DataRequired()])
+    ubicacion_readonly = StringField("Ubicación")
+    tipo_juzgado = SelectField("Tipo de Instancia", choices=ArcDocumento.TIPO_JUZGADOS, validators=[DataRequired()])
+    # Campos opcionales para la bitácora o historial
+    fojas = IntegerField("Fojas", validators=[DataRequired()])
+    notas = TextAreaField("Notas", validators=[Optional(), Length(max=256)])
+    crear = SubmitField("Crear")
+
+
 class ArcDocumentoEditArchivoForm(FlaskForm):
     """Formulario modificar Documento"""
 

--- a/plataforma_web/blueprints/arc_documentos/forms.py
+++ b/plataforma_web/blueprints/arc_documentos/forms.py
@@ -94,3 +94,23 @@ class ArcDocumentoEditSolicitanteForm(FlaskForm):
     notas = TextAreaField("Notas", validators=[Optional(), Length(max=256)])
     observaciones = TextAreaField("Motivo", validators=[DataRequired(), Length(min=5, max=256)])
     guardar = SubmitField("Guardar")
+
+
+class ArcDocumentoEditNoUbicacionForm(FlaskForm):
+    """Formulario modificar Documento"""
+
+    expediente = StringField("Núm. Expediente (999/año)", validators=[DataRequired(), Length(max=16), Regexp(EXPEDIENTE_REGEXP)])
+    anio = IntegerField("Año", validators=[DataRequired(), NumberRange(1900, date.today().year)])
+    juzgado_id = SelectField("Instancia", coerce=int, validate_choice=False, validators=[DataRequired()])
+    actor = StringField("Actor(es)", validators=[DataRequired(), Length(max=256)])
+    demandado = StringField("Demandado(s)", validators=[Optional(), Length(max=256)])
+    juicio = StringField("Juicio", validators=[Optional(), Length(max=128)])
+    juzgado_origen = QuerySelectField("Instancia de Origen", query_factory=juzgados_extintos_opciones, get_label="nombre", validators=[Optional()], allow_blank=True)
+    tipo = SelectField("Tipo de Documento", coerce=int, validate_choice=False, validators=[DataRequired()])
+    ubicacion_readonly = StringField("Ubicación")
+    tipo_juzgado = SelectField("Tipo de Instancia", choices=ArcDocumento.TIPO_JUZGADOS, validators=[DataRequired()])
+    # Campos opcionales para la bitácora o historial
+    fojas = IntegerField("Fojas", validators=[DataRequired()])
+    notas = TextAreaField("Notas", validators=[Optional(), Length(max=256)])
+    observaciones = TextAreaField("Motivo", validators=[DataRequired(), Length(min=5, max=256)])
+    guardar = SubmitField("Guardar")

--- a/plataforma_web/blueprints/arc_documentos/views.py
+++ b/plataforma_web/blueprints/arc_documentos/views.py
@@ -26,6 +26,7 @@ from plataforma_web.blueprints.arc_solicitudes.models import ArcSolicitud
 from plataforma_web.blueprints.arc_documentos.forms import (
     ArcDocumentoNewArchivoForm,
     ArcDocumentoNewSolicitanteForm,
+    ArcDocumentoNewNoUbicacionForm,
     ArcDocumentoEditArchivoForm,
     ArcDocumentoEditSolicitanteForm,
     ArcDocumentoEditNoUbicacionForm,
@@ -199,7 +200,10 @@ def new():
     """Nuevo Documento"""
     mostrar_secciones = {}
     current_user_roles = current_user.get_roles()
-    if ROL_JEFE_REMESA in current_user_roles or current_user.can_admin(MODULO) or ROL_LEVANTAMENTISTA in current_user_roles or ROL_JEFE_REMESA_ADMINISTRADOR in current_user_roles:
+    if ROL_ARCHIVISTA in current_user_roles and ROL_LEVANTAMENTISTA in current_user_roles:
+        form = ArcDocumentoNewNoUbicacionForm()
+        mostrar_secciones["select_juzgado"] = True
+    elif ROL_JEFE_REMESA in current_user_roles or current_user.can_admin(MODULO) or ROL_LEVANTAMENTISTA in current_user_roles or ROL_JEFE_REMESA_ADMINISTRADOR in current_user_roles:
         form = ArcDocumentoNewArchivoForm()
         mostrar_secciones["select_juzgado"] = True
     else:
@@ -218,6 +222,9 @@ def new():
         if isinstance(form, ArcDocumentoNewArchivoForm):
             juzgado_id = int(form.juzgado_id.data)
             ubicacion = safe_string(form.ubicacion.data)
+        elif isinstance(form, ArcDocumentoNewNoUbicacionForm):
+            juzgado_id = int(form.juzgado_id.data)
+            ubicacion = "ARCHIVO"
         else:
             juzgado_id = current_user.autoridad.id
             ubicacion = "JUZGADO"
@@ -272,6 +279,8 @@ def new():
     # Bloquear campos según el ROL
     if isinstance(form, ArcDocumentoNewArchivoForm):
         form.ubicacion.data = "ARCHIVO"
+    elif isinstance(form, ArcDocumentoNewNoUbicacionForm):
+        form.ubicacion_readonly.data = "ARCHIVO"
     else:
         form.juzgado_readonly.data = f"{current_user.autoridad.clave} : {current_user.autoridad.descripcion_corta}"
         form.ubicacion_readonly.data = "JUZGADO"

--- a/plataforma_web/blueprints/arc_documentos/views.py
+++ b/plataforma_web/blueprints/arc_documentos/views.py
@@ -28,6 +28,7 @@ from plataforma_web.blueprints.arc_documentos.forms import (
     ArcDocumentoNewSolicitanteForm,
     ArcDocumentoEditArchivoForm,
     ArcDocumentoEditSolicitanteForm,
+    ArcDocumentoEditNoUbicacionForm,
 )
 
 from plataforma_web.blueprints.arc_archivos.views import (
@@ -283,7 +284,9 @@ def edit(arc_documento_id):
     """Editar Documento"""
     documento = ArcDocumento.query.get_or_404(arc_documento_id)
     current_user_roles = current_user.get_roles()
-    if ROL_JEFE_REMESA in current_user_roles or current_user.can_admin(MODULO) or ROL_LEVANTAMENTISTA in current_user_roles or ROL_JEFE_REMESA_ADMINISTRADOR in current_user_roles:
+    if ROL_ARCHIVISTA in current_user_roles and ROL_LEVANTAMENTISTA in current_user_roles:
+        form = ArcDocumentoEditNoUbicacionForm()
+    elif ROL_JEFE_REMESA in current_user_roles or current_user.can_admin(MODULO) or ROL_LEVANTAMENTISTA in current_user_roles or ROL_JEFE_REMESA_ADMINISTRADOR in current_user_roles:
         form = ArcDocumentoEditArchivoForm()
     else:
         form = ArcDocumentoEditSolicitanteForm()
@@ -303,6 +306,9 @@ def edit(arc_documento_id):
         if isinstance(form, ArcDocumentoEditArchivoForm):
             juzgado_id = int(form.juzgado_id.data)
             ubicacion = safe_string(form.ubicacion.data)
+        elif isinstance(form, ArcDocumentoEditNoUbicacionForm):
+            juzgado_id = int(form.juzgado_id.data)
+            ubicacion = documento.ubicacion
         else:
             juzgado_id = current_user.autoridad.id
             ubicacion = documento.ubicacion
@@ -368,6 +374,9 @@ def edit(arc_documento_id):
     if isinstance(form, ArcDocumentoEditArchivoForm):
         form.juzgado_id.data = documento.autoridad_id
         form.ubicacion.data = documento.ubicacion
+    elif isinstance(form, ArcDocumentoEditNoUbicacionForm):
+        form.juzgado_id.data = documento.autoridad_id
+        form.ubicacion_readonly.data = documento.ubicacion
     else:
         form.juzgado_readonly.data = f"{current_user.autoridad.clave} : {current_user.autoridad.descripcion_corta}"
         form.ubicacion_readonly.data = documento.ubicacion


### PR DESCRIPTION
Los roles combinados de <kbd>ARCHIVISTA</kbd> + <kbd>LEVANTAMENTISTA</kbd> no pueden editar el campo de ubicación al editar o crear un nuevo expediente.

close #741 