### PR TITLE
Archivo - Pase automático de solicitudes y remesas canceladas al historial

### DIFF
--- a/cli/commands/cmd_archivos.py
+++ b/cli/commands/cmd_archivos.py
@@ -55,9 +55,19 @@ def pasar_al_historial():
     """Pasar al historial las solicitudes y remesas con mucha antigüedad habiendo sido procesadas correctamente"""
 
     app.task_queue.enqueue(
-        "plataforma_web.blueprints.arc_archivos.tasks.pasar_al_historial_solicitudes_remesas",
+        "plataforma_web.blueprints.arc_archivos.tasks.pasar_al_historial_solicitudes_completadas",
     )
-    click.echo("Pasar al historial las solicitudes y remesas atendidas.")
+    click.echo("Pasar al historial las solicitudes atendidas.")
+
+    app.task_queue.enqueue(
+        "plataforma_web.blueprints.arc_archivos.tasks.pasar_al_historial_solicitudes_canceladas",
+    )
+    click.echo("Pasar al historial las solicitudes canceladas.")
+
+    app.task_queue.enqueue(
+        "plataforma_web.blueprints.arc_archivos.tasks.pasar_al_historial_remesas_canceladas",
+    )
+    click.echo("Pasar al historial las remesas canceladas.")
 
 
 cli.add_command(actualizar_expedientes_anios_nums)

--- a/plataforma_web/blueprints/arc_archivos/tasks.py
+++ b/plataforma_web/blueprints/arc_archivos/tasks.py
@@ -18,6 +18,7 @@ from plataforma_web.blueprints.usuarios.models import Usuario
 load_dotenv()  # Take environment variables from .env
 
 DIAS_ANTIGUEDAD = 0
+DIAS_ANTIGUEDAD_CANCELADAS = 2
 USUARIO_DEFECTO = "archivo@pjecz.gob.mx"
 
 bitacora = logging.getLogger(__name__)
@@ -33,7 +34,7 @@ app.app_context().push()
 locale.setlocale(locale.LC_TIME, "es_MX.utf8")
 
 
-def pasar_al_historial_solicitudes_remesas():
+def pasar_al_historial_solicitudes_completadas():
     """Pasar al historial las solicitudes y remesas con mucha antigüedad habiendo sido procesadas correctamente"""
 
     # Fecha
@@ -64,23 +65,81 @@ def pasar_al_historial_solicitudes_remesas():
         ).save()
     bitacora.info("Se han pasado al historial %d solicitudes con fechas de recibido mayor a %d días.", contador, DIAS_ANTIGUEDAD)
 
-    set_task_progress(50)
+    # Terminar tarea
+    set_task_progress(100)
+    mensaje_final = "Terminado satisfactoriamente"
+    bitacora.info(mensaje_final)
+    return mensaje_final
 
-    # # Selección de remesas con más de tantos días de antigüedad y en estado de ARCHIVADO
-    # remesas = ArcRemesa.query.filter_by(estado="ARCHIVADO").filter_by(esta_archivado=False).filter(ArcRemesa.modificado <= fecha_limite).all()
-    # contador = 0
-    # for remesa in remesas:
-    #     remesa.esta_archivado = True
-    #     remesa.save()
-    #     contador += 1
-    #     # Añadir acción a la bitácora de remesas
-    #     ArcRemesaBitacora(
-    #         arc_remesa=remesa,
-    #         usuario=usuario,
-    #         accion="PASADA AL HISTORIAL",
-    #         observaciones="Tarea programada",
-    #     ).save()
-    # bitacora.info("Se han pasado al historial %d remesas con fechas de recibido mayor a %d días.", contador, DIAS_ANTIGUEDAD)
+
+def pasar_al_historial_solicitudes_canceladas():
+    """Pasar al historial las solicitudes con determinados días de antigüedad teniendo el estado de canceladas"""
+
+    # Fecha
+    fecha_limite = date.today() - timedelta(days=DIAS_ANTIGUEDAD_CANCELADAS)
+
+    # Ubicar al usuario responsable para dicha operación
+    usuario = Usuario.query.filter_by(email=USUARIO_DEFECTO).filter_by(estatus="A").first()
+    if not usuario:
+        mensaje_final = f"ERROR: usuario por defecto no localizado '{USUARIO_DEFECTO}'"
+        bitacora.error(mensaje_final)
+        return mensaje_final
+
+    set_task_progress(1)
+
+    # Selección de solicitudes con más de tantos días de antigüedad y en estado de recibidos
+    solicitudes = ArcSolicitud.query.filter_by(estado="CANCELADO").filter_by(esta_archivado=False).filter(ArcSolicitud.modificado <= fecha_limite).all()
+    contador = 0
+    for solicitud in solicitudes:
+        solicitud.esta_archivado = True
+        solicitud.save()
+        contador += 1
+        # Añadir acción a la bitácora de Solicitudes
+        ArcSolicitudBitacora(
+            arc_solicitud=solicitud,
+            usuario=usuario,
+            accion="PASADA AL HISTORIAL",
+            observaciones="Tarea programada",
+        ).save()
+    bitacora.info("Se han pasado al historial %d solicitudes canceladas con más de %d días.", contador, DIAS_ANTIGUEDAD_CANCELADAS)
+
+    # Terminar tarea
+    set_task_progress(100)
+    mensaje_final = "Terminado satisfactoriamente"
+    bitacora.info(mensaje_final)
+    return mensaje_final
+
+
+def pasar_al_historial_remesas_canceladas():
+    """Pasar al historial las remesas con determinados días de antigüedad teniendo el estado de canceladas"""
+
+    # Fecha
+    fecha_limite = date.today() - timedelta(days=DIAS_ANTIGUEDAD_CANCELADAS)
+
+    # Ubicar al usuario responsable para dicha operación
+    usuario = Usuario.query.filter_by(email=USUARIO_DEFECTO).filter_by(estatus="A").first()
+    if not usuario:
+        mensaje_final = f"ERROR: usuario por defecto no localizado '{USUARIO_DEFECTO}'"
+        bitacora.error(mensaje_final)
+        return mensaje_final
+
+    set_task_progress(1)
+
+    # Selección de remesas con más de tantos días de antigüedad y en estado de cancelada
+    remesas = ArcRemesa.query.filter_by(estado="CANCELADO").filter_by(esta_archivado=False).filter(ArcRemesa.modificado <= fecha_limite).all()
+    contador = 0
+    for remesa in remesas:
+        remesa.esta_archivado = True
+        remesa.save()
+        contador += 1
+        # Añadir acción a la bitácora de remesas
+        ArcRemesaBitacora(
+            arc_remesa=remesa,
+            usuario=usuario,
+            accion="PASADA AL HISTORIAL",
+            observaciones="Tarea programada",
+        ).save()
+    bitacora.info("Se han pasado al historial %d remesas canceladas con más de %d días.", contador, DIAS_ANTIGUEDAD_CANCELADAS)
 
     # Terminar tarea
     set_task_progress(100)


### PR DESCRIPTION
Tarea en el fondo para pasar las **Solicitudes** y **Remesas** canceladas con más de 2 días de antigüedad al historial de forma automática.

> [!NOTE]
> Hacer GIT PULL en Diana para ver reflejado las tareas

Close #799 