### PR TITLE
Archivo - Mejoras en nombres de filtros de listados

### DIFF
--- a/plataforma_web/blueprints/arc_archivos/CHANGELOG.md
+++ b/plataforma_web/blueprints/arc_archivos/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog - Archivo
 
+## 2023-Octubre
+
+**Mejoras**:
+
+- Quitar filtro **Año** en listado de remesas. [\#851](https://github.com/PJECZ/pjecz-plataforma-web/issues/851)
+- Corrección de nombre de filtro en listado de solicitudes, campo **Expediente** por **No. Doc**.
+
 ## 2023-Septiembre
 
 **Closed issues**:

--- a/plataforma_web/blueprints/arc_archivos/templates/arc_archivos/list_archivista.jinja2
+++ b/plataforma_web/blueprints/arc_archivos/templates/arc_archivos/list_archivista.jinja2
@@ -44,7 +44,7 @@
                     <div class="col-2">
                         <div class="form-floating">
                             <input id="documentoInput_solicitud" type="text" class="form-control" aria-label="Documento" onchange="filtros_solicitudes.buscar(); return false;">
-                            <label for="documentoInput_solicitud">Expediente</label>
+                            <label for="documentoInput_solicitud">No. Doc</label>
                         </div>
                     </div>
                     <div class="col-2">
@@ -99,13 +99,7 @@
                             <label for="juzgadoInput_remesa">Instancia</label>
                         </div>
                     </div>
-                    <div class="col-2">
-                        <div class="form-floating">
-                            <input id="anioInput_remesa" type="text" class="form-control" onchange="filtros_remesas.buscar(); return false;">
-                            <label for="anioInput_remesa">Año</label>
-                        </div>
-                    </div>
-                    <div class="col-2">
+                    <div class="col-4">
                         <div class="form-floating">
                             <input id="numOficioInput_remesa" type="text" class="form-control" onchange="filtros_remesas.buscar(); return false;">
                             <label for="numOficioInput_remesa">Núm. Oficio</label>

--- a/plataforma_web/blueprints/arc_archivos/templates/arc_archivos/list_jefe_remesa.jinja2
+++ b/plataforma_web/blueprints/arc_archivos/templates/arc_archivos/list_jefe_remesa.jinja2
@@ -87,7 +87,7 @@
                     <div class="col-3">
                         <div class="form-floating">
                             <input id="documentoInput_solicitud" type="text" class="form-control" aria-label="Documento" onchange="filtros_solicitudes.buscar(); return false;">
-                            <label for="documentoInput_solicitud">Expediente</label>
+                            <label for="documentoInput_solicitud">No. Doc</label>
                         </div>
                     </div>
                     <div class="col-4">
@@ -148,13 +148,7 @@
                             <label for="juzgadoInput_remesa">Instancia</label>
                         </div>
                     </div>
-                    <div class="col-2">
-                        <div class="form-floating">
-                            <input id="anioInput_remesa" type="text" class="form-control" onchange="filtros_remesas.buscar(); return false;">
-                            <label for="anioInput_remesa">Año</label>
-                        </div>
-                    </div>
-                    <div class="col-2">
+                    <div class="col-4">
                         <div class="form-floating">
                             <input id="numOficioInput_remesa" type="text" class="form-control" onchange="filtros_remesas.buscar(); return false;">
                             <label for="numOficioInput_remesa">Núm. Oficio</label>

--- a/plataforma_web/blueprints/arc_archivos/templates/arc_archivos/list_solicitante.jinja2
+++ b/plataforma_web/blueprints/arc_archivos/templates/arc_archivos/list_solicitante.jinja2
@@ -59,7 +59,7 @@
                     <div class="col-4">
                         <div class="form-floating">
                             <input id="documentoInput_solicitud" type="text" class="form-control" aria-label="Documento" onchange="filtros_solicitudes.buscar(); return false;">
-                            <label for="documentoInput_solicitud">Documento</label>
+                            <label for="documentoInput_solicitud">No. Doc</label>
                         </div>
                     </div>
                     <div class="col-4">
@@ -87,7 +87,7 @@
                     <th>ID</th>
                     <th>Creado</th>
                     <th>Tipo</th>
-                    <th>Documento</th>
+                    <th>No. Doc</th>
                     <th>Estado</th>
                 </tr>
             </thead>
@@ -103,19 +103,13 @@
         <div class="row">
             <div class="col">
                 <form class="row g-1 mb-3" id="buscadorForm" onsubmit="filtros_remesas.buscar(); return false;" autocomplete="off">
-                    <div class="col-4">
+                    <div class="col-6">
                         <div class="form-floating">
                             <input id="idInput_remesa" type="text" class="form-control" onchange="filtros_remesas.buscar(); return false;">
                             <label for="idInput_remesa">ID</label>
                         </div>
                     </div>
-                    <div class="col-4">
-                        <div class="form-floating">
-                            <input id="anioInput_remesa" type="text" class="form-control" onchange="filtros_remesas.buscar(); return false;">
-                            <label for="anioInput_remesa">Año</label>
-                        </div>
-                    </div>
-                    <div class="col-4">
+                    <div class="col-6">
                         <div class="form-floating">
                             <select id="tipoDocumentoInput_remesa" class="form-control js-select2-filter" onchange="filtros_remesas.buscar(); return false;" style="text-transform: uppercase"></select>
                             <label for="tipoDocumentoInput_remesa">Tipo de Documento</label>

--- a/plataforma_web/blueprints/arc_remesas/templates/arc_remesas/detail.jinja2
+++ b/plataforma_web/blueprints/arc_remesas/templates/arc_remesas/detail.jinja2
@@ -101,7 +101,7 @@
                     <div class="col-4">
                         <div class="form-floating">
                             <input id="expedienteInput_docsAnexos" type="text" class="form-control" onchange="buscar_docsAnexos(); return false;">
-                            <label for="expedienteInput_docsAnexos">Expediente</label>
+                            <label for="expedienteInput_docsAnexos">Documento</label>
                         </div>
                     </div>
                     <div class="col-4 text-end">

--- a/plataforma_web/blueprints/arc_remesas/templates/arc_remesas/detail_archivista.jinja2
+++ b/plataforma_web/blueprints/arc_remesas/templates/arc_remesas/detail_archivista.jinja2
@@ -100,7 +100,7 @@
                     <div class="col-4">
                         <div class="form-floating">
                             <input id="expedienteInput_docsAnexos" type="text" class="form-control" onchange="buscar_docsAnexos(); return false;">
-                            <label for="expedienteInput_docsAnexos">Expediente</label>
+                            <label for="expedienteInput_docsAnexos">Documento</label>
                         </div>
                     </div>
                     <div class="col-4 text-end">

--- a/plataforma_web/blueprints/arc_remesas/templates/arc_remesas/detail_solicitante.jinja2
+++ b/plataforma_web/blueprints/arc_remesas/templates/arc_remesas/detail_solicitante.jinja2
@@ -99,7 +99,7 @@
                     <div class="col-4">
                         <div class="form-floating">
                             <input id="expedienteInput_docsAnexos" type="text" class="form-control" onchange="buscar_docsAnexos(); return false;">
-                            <label for="expedienteInput_docsAnexos">Expediente</label>
+                            <label for="expedienteInput_docsAnexos">Documento</label>
                         </div>
                     </div>
                     <div class="col-4 text-end">


### PR DESCRIPTION
Se colocaron los nombres de los filtros igual al de los campos para evitar confuciones por parte de los usuarios.

Ese eliminó el filtro de años en remesas

Closes: #851