### PR TITLE
Archivo - Columna origen al listado de expedientes

### DIFF
--- a/plataforma_web/blueprints/arc_archivos/CHANGELOG.md
+++ b/plataforma_web/blueprints/arc_archivos/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Quitar filtro **Año** en listado de remesas. [\#851](https://github.com/PJECZ/pjecz-plataforma-web/issues/851)
 - Corrección de nombre de filtro en listado de solicitudes, campo **Expediente** por **No. Doc**.
+- Añadir columna juzgado origen al listado de expedientes. [\#853](https://github.com/PJECZ/pjecz-plataforma-web/issues/853)
 
 ## 2023-Septiembre
 

--- a/plataforma_web/blueprints/arc_documentos/templates/arc_documentos/list_admin.jinja2
+++ b/plataforma_web/blueprints/arc_documentos/templates/arc_documentos/list_admin.jinja2
@@ -139,7 +139,12 @@
                 targets: 1, // juzgado
                 data: null,
                 render: function(data, type, row, meta) {
-                    texto = '<span title="' + data.nombre_actual + '"><a href="' + data.url_actual + '">' + data.clave_actual + '</span></a>';
+                    if (data.url_actual == "") {
+                        texto = data.clave_actual;
+                    } else {
+                        texto =  '<a href="' + data.url_actual + '">' + data.clave_actual + '</a>';
+                    }
+                    texto = '<span title="' + data.nombre_actual + '">' + texto + '</span>';
                     if (data.clave_origen != ""){
                         texto += '<br /><strong>Origen:</strong> ';
                         texto += '<span title="' + data.nombre_origen + '">' + data.clave_origen + '</span>';

--- a/plataforma_web/blueprints/arc_documentos/templates/arc_documentos/list_admin.jinja2
+++ b/plataforma_web/blueprints/arc_documentos/templates/arc_documentos/list_admin.jinja2
@@ -121,7 +121,7 @@
         configDataTable_documentos['ajax']['data'] = {{ filtros }};
         configDataTable_documentos['columns'] = [
             { data: 'expediente' },
-            { data: 'juzgado' },
+            { data: 'juzgado_y_origen' },
             { data: 'tipo' },
             { data: 'juicio' },
             { data: 'partes' },
@@ -139,7 +139,12 @@
                 targets: 1, // juzgado
                 data: null,
                 render: function(data, type, row, meta) {
-                    return '<span title="' + data.nombre + '"><a href="' + data.url + '">' + data.clave + '</span></a>';
+                    texto = '<span title="' + data.nombre_actual + '"><a href="' + data.url_actual + '">' + data.clave_actual + '</span></a>';
+                    if (data.clave_origen != ""){
+                        texto += '<br /><strong>Origen:</strong> ';
+                        texto += '<span title="' + data.nombre_origen + '">' + data.clave_origen + '</span>';
+                    }
+                    return texto;
                 }
             },
             {

--- a/plataforma_web/blueprints/arc_documentos/views.py
+++ b/plataforma_web/blueprints/arc_documentos/views.py
@@ -113,6 +113,13 @@ def datatable_json():
                     "nombre": resultado.autoridad.descripcion_corta,
                     "url": url_for("autoridades.detail", autoridad_id=resultado.autoridad.id),
                 },
+                "juzgado_y_origen": {
+                    "clave_actual": resultado.autoridad.clave,
+                    "nombre_actual": resultado.autoridad.descripcion_corta,
+                    "url_actual": url_for("autoridades.detail", autoridad_id=resultado.autoridad.id),
+                    "clave_origen": resultado.arc_juzgado_origen.clave if resultado.arc_juzgado_origen_id != None else "",
+                    "nombre_origen": resultado.arc_juzgado_origen.descripcion_corta if resultado.arc_juzgado_origen_id != None else "",
+                },
                 "anio": resultado.anio,
                 "tipo": resultado.arc_documento_tipo.nombre,
                 "fojas": resultado.fojas,

--- a/plataforma_web/blueprints/arc_documentos/views.py
+++ b/plataforma_web/blueprints/arc_documentos/views.py
@@ -111,12 +111,12 @@ def datatable_json():
                 "juzgado": {
                     "clave": resultado.autoridad.clave,
                     "nombre": resultado.autoridad.descripcion_corta,
-                    "url": url_for("autoridades.detail", autoridad_id=resultado.autoridad.id),
+                    "url": url_for("autoridades.detail", autoridad_id=resultado.autoridad.id) if current_user.can_view("AUTORIDADES") else "",
                 },
                 "juzgado_y_origen": {
                     "clave_actual": resultado.autoridad.clave,
                     "nombre_actual": resultado.autoridad.descripcion_corta,
-                    "url_actual": url_for("autoridades.detail", autoridad_id=resultado.autoridad.id),
+                    "url_actual": url_for("autoridades.detail", autoridad_id=resultado.autoridad.id) if current_user.can_view("AUTORIDADES") else "",
                     "clave_origen": resultado.arc_juzgado_origen.clave if resultado.arc_juzgado_origen_id != None else "",
                     "nombre_origen": resultado.arc_juzgado_origen.descripcion_corta if resultado.arc_juzgado_origen_id != None else "",
                 },


### PR DESCRIPTION
Añadido la columna de instancia de origen al listado de expedientes. se añadio en la misma columna de **Instancia** para ahorrar espacio horizontal. Si no tiene ese campo aparecera vacío.

Close: #853